### PR TITLE
Allow a custom value attribute for checkboxes

### DIFF
--- a/module202/app203/views204/b3205/checkbox.scala.html
+++ b/module202/app203/views204/b3205/checkbox.scala.html
@@ -9,7 +9,7 @@
 	@inputFormGroup(field, withFeedback = false, withLabelFor = false, Args.withDefault(args, 'disabled -> disabled)) { fieldInfo =>
 		<div class="checkbox@if(containsReadonly){ checkbox-group}@if(disabled){ disabled}">
 			<label for="@fieldInfo.id">
-				<input type="checkbox" id="@fieldInfo.id" name="@fieldInfo.name" value="true"@if(fieldInfo.value == Some("true")){ checked} @toHtmlArgs(fieldInfo.innerArgsMap)>
+				<input type="checkbox" id="@fieldInfo.id" name="@fieldInfo.name" value="@argsMap.get('value)"@if(fieldInfo.value == Some("true")){ checked} @toHtmlArgs(fieldInfo.innerArgsMap)>
 				@argsMap.get('_text)
 			</label>
 			@if(containsReadonly) {


### PR DESCRIPTION
This is needed in case of repeated checkboxes. Instead of returning a list of booleans to the controller this allows to return a list of strings.

A list of booleans is not sufficient since play only returns those set to true, thus making it impossible to determine which checkboxes are checked and which ones are not.

This change allows the following use case:

```scala
@for((options,i) <- options.zipWithIndex) {
   @helpers.checkbox( registerForm("options["+ i +"]"), '_label -> Messages(option), 'value -> option )
}