### PR TITLE
b4-alpha3 form-group and label updates

### DIFF
--- a/play24-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
@@ -1,9 +1,9 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html, extraClasses: Option[String] = None)(wrap: Html => Html)
-<fieldset class="form-group @extraClasses @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
+<div class="form-group @extraClasses @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
 	@wrap {
 		@inputHtml
 		@fieldInfo.errorsAndInfos.map { case (id, text) =>
-			<span id="@id" class="help-block">@text</span>
+			<span id="@id" class="form-control-feedback">@text</span>
 		}
 	}
-</fieldset>
+</div>

--- a/play24-bootstrap4/module/app/views/b4/bsFormGroupCommon.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/bsFormGroupCommon.scala.html
@@ -1,11 +1,11 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(wrap: Html => Html)(implicit messages: Messages)
 @defining(argsMap.get('_id).map(_.toString).orElse(argsMap.get('id).map(_.toString + "_field"))) { idFormField =>
-	<fieldset class="form-group @argsMap.get('_class)" @idFormField.map{id=>id="@id"}>
+	<div class="form-group @argsMap.get('_class)" @idFormField.map{id=>id="@id"}>
 		@wrap {
 			@contentHtml
 			@argsMap.get('_help).map { help =>
 				<span class="help-block">@bs.Args.msg(help)(messages)</span>
 			}
 		}
-	</fieldset>
+	</div>
 }

--- a/play24-bootstrap4/module/app/views/b4/horizontal/bsFieldConstructor.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/horizontal/bsFieldConstructor.scala.html
@@ -1,7 +1,7 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html, colLabel: String, colOffset: String, colInput: String)(implicit messages: Messages)
 @b4.bsFieldConstructorCommon(fieldInfo, inputHtml, extraClasses = Some("row")) { content =>
 	@fieldInfo.labelOpt.map { label =>
-		<label class="control-label form-control-label @colLabel@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+		<label class="col-form-label @colLabel@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 		<div class="@colInput">
 			@content
 		</div>

--- a/play24-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any], colLabel: String, colOffset: String, colInput: String)(implicit messages: Messages)
 @b4.bsFormGroupCommon(contentHtml, bs.ArgsMap.withAddingStringValue(argsMap, '_class, "row")) { content =>
 	@argsMap.get('_label).map { label =>
-		<label class="control-label form-control-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="col-form-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 		<div class="@colInput">
 			@content
 		</div>

--- a/play24-bootstrap4/module/app/views/b4/horizontal/package.scala
+++ b/play24-bootstrap4/module/app/views/b4/horizontal/package.scala
@@ -27,11 +27,8 @@ package object horizontal {
    * It needs the column widths for the corresponding Bootstrap3 form-group
    */
   case class HorizontalFieldConstructor(colLabel: String, colInput: String) extends B4FieldConstructor {
-    /* The equivalent offset if label is not present (ex: colLabel = "col-md-2"  =>  colOffset = "col-md-offset-2") */
-    val colOffset: String = {
-      val chunks = colLabel.split("-")
-      (chunks.init :+ "offset" :+ chunks.last).mkString("-")
-    }
+    /* The equivalent offset if label is not present (ex: colLabel = "col-md-2"  =>  colOffset = "offset-md-2") */
+    val colOffset: String = colLabel.replace("col", "offset")
     /* Define the class of the corresponding form */
     val formClass = "form-horizontal"
     /* Renders the corresponding template of the field constructor */

--- a/play24-bootstrap4/module/app/views/b4/inline/bsFieldConstructor.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/inline/bsFieldConstructor.scala.html
@@ -1,7 +1,7 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html)(implicit messages: Messages)
 @b4.bsFieldConstructorCommon(fieldInfo, inputHtml) { content =>
 	@fieldInfo.labelOpt.map { label =>
-		<label class="control-label@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+		<label class="@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play24-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: Messages)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get('_label).map { label =>
-		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play24-bootstrap4/module/app/views/b4/package.scala
+++ b/play24-bootstrap4/module/app/views/b4/package.scala
@@ -43,7 +43,7 @@ package object b4 {
       else (false, false, isTrue(argsMap, '_showIconValid))
     }
 
-    /* The optional validation state ("success", "warning" or "error") */
+    /* The optional validation state ("success", "warning" or "danger") */
     override lazy val status: Option[String] = B4FieldInfo.status(hasErrors, argsMap)
 
     /* Indicates if any of the previous feedback icons should be shown */
@@ -76,10 +76,10 @@ package object b4 {
    * Companion object for class B4FieldInfo
    */
   object B4FieldInfo {
-    /* The optional validation state ("success", "warning" or "error") */
+    /* The optional validation state ("success", "warning" or "danger") */
     def status(hasErrors: Boolean, argsMap: Map[Symbol, Any]): Option[String] = {
       if (hasErrors)
-        Some("error")
+        Some("danger")
       else if (ArgsMap.isNotFalse(argsMap, '_warning) || isTrue(argsMap, '_showIconWarning))
         Some("warning")
       else if (ArgsMap.isNotFalse(argsMap, '_success) || isTrue(argsMap, '_showIconValid))
@@ -95,7 +95,7 @@ package object b4 {
    * - args: list of available arguments for the helper and the form-group
    */
   case class B4MultifieldInfo(fields: Seq[Field], globalArguments: Seq[(Symbol, Any)], fieldsArguments: Seq[(Symbol, Any)], override val messages: Messages) extends BSMultifieldInfo(fields, globalArguments, fieldsArguments, messages) {
-    /* The optional validation state ("success", "warning" or "error") */
+    /* The optional validation state ("success", "warning" or "danger") */
     override lazy val status: Option[String] = B4FieldInfo.status(hasErrors, argsMap)
 
     override lazy val globalArgs = {

--- a/play24-bootstrap4/module/app/views/b4/selectWithContent.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/selectWithContent.scala.html
@@ -12,7 +12,7 @@
 	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
 	val multiple = bs.ArgsMap.isTrue(argsMap, 'multiple)
-  val defaultClass = if (bs.ArgsMap.isTrue(argsMap, '_custom)) "c-select" else "form-control"
+  val defaultClass = if (bs.ArgsMap.isTrue(argsMap, '_custom)) "custom-select" else "form-control"
 	(argsMap, disabled, multiple, defaultClass)
 }) { case (argsMap, disabled, multiple, defaultClass) =>
 	@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(bs.Args.withAddingStringValue(args, 'class, defaultClass), 'disabled -> disabled)) { fieldInfo =>

--- a/play24-bootstrap4/module/app/views/b4/vertical/bsFieldConstructor.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/vertical/bsFieldConstructor.scala.html
@@ -1,7 +1,7 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html)(implicit messages: Messages)
 @b4.bsFieldConstructorCommon(fieldInfo, inputHtml) { content =>
 	@fieldInfo.labelOpt.map { label =>
-		<label class="control-label@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+		<label class="@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play24-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
+++ b/play24-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: Messages)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get('_label).map { label =>
-		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play24-bootstrap4/module/test/FieldConstructorsSpec.scala
+++ b/play24-bootstrap4/module/test/FieldConstructorsSpec.scala
@@ -91,31 +91,31 @@ object FieldConstructorsSpec extends Specification {
     "allow rendering errors" in {
       val test = simpleInputWithError()
       test must contain("has-danger")
-      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
+      test must contain("<div id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</div>")
+      test must contain("<div id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</div>")
     }
 
     "allow showing constraints" in {
       val test = simpleInputWithArgs('_showConstraints -> true)
-      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">")
-      test must contain("<span id=\"foo_info_1\" class=\"form-control-feedback\">")
-      test must contain("class=\"form-control-feedback\">" + messages("constraint.required") + "</span>")
-      test must contain("class=\"form-control-feedback\">" + messages("constraint.maxLength", 8) + "</span>")
+      test must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">")
+      test must contain("<div id=\"foo_info_1\" class=\"form-control-feedback\">")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.required") + "</div>")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.maxLength", 8) + "</div>")
     }
 
     "allow showing help info" in {
-      simpleInputWithArgs('_help -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      simpleInputWithArgs('_success -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      simpleInputWithArgs('_warning -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      simpleInputWithArgs('_error -> "test-help") must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_help -> "test-help") must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      simpleInputWithArgs('_success -> "test-help") must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      simpleInputWithArgs('_warning -> "test-help") must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      simpleInputWithArgs('_error -> "test-help") must contain("<div id=\"foo_error_0\" class=\"form-control-feedback\">test-help</div>")
     }
 
     "allow rendering erros and hide constraints when help info is present" in {
       val test = simpleInputWithError('_showConstraints -> true, '_help -> "test-help")
-      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
-      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      test must not contain ("<span id=\"foo_info_1\"")
+      test must contain("<div id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</div>")
+      test must contain("<div id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</div>")
+      test must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      test must not contain ("<div id=\"foo_info_1\"")
     }
 
     "render validation states" in {
@@ -160,16 +160,16 @@ object FieldConstructorsSpec extends Specification {
       test1 must contain("aria-invalid=\"true\"")
       test1 must contain("aria-describedby=\"foo_status foo_info_0 foo_info_1 foo_error_0 foo_error_1\"")
       test1 must contain("<span id=\"foo_status\"")
-      test1 must contain("<span id=\"foo_info_0\"")
-      test1 must contain("<span id=\"foo_info_1\"")
-      test1 must contain("<span id=\"foo_error_0\"")
-      test1 must contain("<span id=\"foo_error_1\"")
+      test1 must contain("<div id=\"foo_info_0\"")
+      test1 must contain("<div id=\"foo_info_1\"")
+      test1 must contain("<div id=\"foo_error_0\"")
+      test1 must contain("<div id=\"foo_error_1\"")
 
       val test2 = simpleInputWithArgs('_help -> "test-help", '_showIconValid -> true)
       test2 must not contain ("aria-invalid")
       test2 must contain("aria-describedby=\"foo_status foo_info_0\"")
       test2 must contain("<span id=\"foo_status\"")
-      test2 must contain("<span id=\"foo_info_0\"")
+      test2 must contain("<div id=\"foo_info_0\"")
       test2 must not contain ("<span id=\"foo_error")
     }
   }

--- a/play24-bootstrap4/module/test/FieldConstructorsSpec.scala
+++ b/play24-bootstrap4/module/test/FieldConstructorsSpec.scala
@@ -49,7 +49,7 @@ object FieldConstructorsSpec extends Specification {
       case _ => ""
     }
     val labelExtraClasses = fc match {
-      case hfc: b4.horizontal.HorizontalFieldConstructor => " form-control-label " + hfc.colLabel
+      case hfc: b4.horizontal.HorizontalFieldConstructor => "col-form-label " + hfc.colLabel
       case _ => ""
     }
 
@@ -70,15 +70,15 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow setting extra classes form-group" in {
-      clean(simpleInputWithArgs('_class -> "extra_class another_class")) must contain(s"""<fieldset class="form-group$fieldsetExtraClasses extra_class another_class" """)
+      clean(simpleInputWithArgs('_class -> "extra_class another_class")) must contain(s"""<div class="form-group$fieldsetExtraClasses extra_class another_class" """)
     }
 
     "render the label" in {
-      clean(simpleInputWithArgs('_label -> "theLabel")) must contain(s"""<label class="control-label$labelExtraClasses" for="foo">theLabel</label>""")
+      clean(simpleInputWithArgs('_label -> "theLabel")) must contain(s"""<label class="$labelExtraClasses" for="foo">theLabel</label>""")
     }
 
     "allow hide the label" in {
-      val labelString = s"""<label class="control-label$labelExtraClasses sr-only" for="foo">theLabel</label>"""
+      val labelString = s"""<label class="$labelExtraClasses sr-only" for="foo">theLabel</label>"""
       clean(simpleInputWithArgs('_label -> "theLabel", '_hideLabel -> true)) must contain(labelString)
       clean(simpleInputWithArgs('_hiddenLabel -> "theLabel")) must contain(labelString)
     }
@@ -118,7 +118,7 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "render validation states" in {
-      def withStatus(status: String) = contain(s"""<fieldset class="form-group$fieldsetExtraClasses has-$status"""")
+      def withStatus(status: String) = contain(s"""<div class="form-group$fieldsetExtraClasses has-$status"""")
       def withFeedbackIcon(status: String) = contain(s""" class="form-control-$status form-control"""")
       def testStatus(status: String, withIcon: Boolean, args: (Symbol, Any)*) = {
         val test = clean(simpleInputWithArgs(args: _*))

--- a/play24-bootstrap4/module/test/FieldConstructorsSpec.scala
+++ b/play24-bootstrap4/module/test/FieldConstructorsSpec.scala
@@ -55,7 +55,7 @@ object FieldConstructorsSpec extends Specification {
 
     "have the basic structure" in {
       simpleInput must contain("class=\"form-group")
-      simpleInput must not contain ("has-error")
+      simpleInput must not contain ("has-danger")
       simpleInput must not contain ("aria-invalid")
       simpleInput must contain(testInputString)
       simpleInput must not contain ("class=\"help-block\"")
@@ -78,7 +78,8 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow hide the label" in {
-      val labelString = s"""<label class="$labelExtraClasses sr-only" for="foo">theLabel</label>"""
+      val extraStuff = s"$labelExtraClasses sr-only".trim
+      val labelString = s"""<label class="$extraStuff" for="foo">theLabel</label>"""
       clean(simpleInputWithArgs('_label -> "theLabel", '_hideLabel -> true)) must contain(labelString)
       clean(simpleInputWithArgs('_hiddenLabel -> "theLabel")) must contain(labelString)
     }
@@ -89,31 +90,31 @@ object FieldConstructorsSpec extends Specification {
 
     "allow rendering errors" in {
       val test = simpleInputWithError()
-      test must contain("has-error")
-      test must contain("<span id=\"foo_error_0\" class=\"help-block\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"help-block\">test-error-1</span>")
+      test must contain("has-danger")
+      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
+      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
     }
 
     "allow showing constraints" in {
       val test = simpleInputWithArgs('_showConstraints -> true)
-      test must contain("<span id=\"foo_info_0\" class=\"help-block\">")
-      test must contain("<span id=\"foo_info_1\" class=\"help-block\">")
-      test must contain("class=\"help-block\">" + messages("constraint.required") + "</span>")
-      test must contain("class=\"help-block\">" + messages("constraint.maxLength", 8) + "</span>")
+      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">")
+      test must contain("<span id=\"foo_info_1\" class=\"form-control-feedback\">")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.required") + "</span>")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.maxLength", 8) + "</span>")
     }
 
     "allow showing help info" in {
-      simpleInputWithArgs('_help -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_success -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_warning -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_error -> "test-help") must contain("<span id=\"foo_error_0\" class=\"help-block\">test-help</span>")
+      simpleInputWithArgs('_help -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_success -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_warning -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_error -> "test-help") must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-help</span>")
     }
 
     "allow rendering erros and hide constraints when help info is present" in {
       val test = simpleInputWithError('_showConstraints -> true, '_help -> "test-help")
-      test must contain("<span id=\"foo_error_0\" class=\"help-block\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"help-block\">test-error-1</span>")
-      test must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
+      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
+      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
+      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
       test must not contain ("<span id=\"foo_info_1\"")
     }
 
@@ -134,16 +135,16 @@ object FieldConstructorsSpec extends Specification {
       testStatus("success", withIcon = false, '_success -> "test-help")
       testStatus("warning", withIcon = false, '_warning -> true)
       testStatus("warning", withIcon = false, '_warning -> "test-help")
-      testStatus("error", withIcon = false, '_error -> true)
-      testStatus("error", withIcon = false, '_error -> "test-help")
+      testStatus("danger", withIcon = false, '_error -> true)
+      testStatus("danger", withIcon = false, '_error -> "test-help")
 
       "with feedback icons" in {
         testStatus("success", withIcon = true, '_showIconValid -> true)
         testStatus("success", withIcon = true, '_success -> "test-help", '_showIconValid -> true)
         testStatus("warning", withIcon = true, '_showIconWarning -> true)
         testStatus("warning", withIcon = true, '_warning -> "test-help", '_showIconWarning -> true)
-        testStatus("error", withIcon = true, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, '_error -> true, '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, '_error -> "test-help", '_showIconOnError -> true)
       }
     }
 

--- a/play24-bootstrap4/module/test/HelpersSpec.scala
+++ b/play24-bootstrap4/module/test/HelpersSpec.scala
@@ -514,7 +514,7 @@ object HelpersSpec extends Specification {
     "horizontal: without label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId")(hfc, messages) must be equalTo clean("""
 	  <div class="form-group row theClass" id="theId">
-	  	<div class="col-md-10 col-md-offset-2">
+	  	<div class="col-md-10 offset-md-2">
 	  	  <content>
 	  	</div>
 	  </div>
@@ -656,7 +656,7 @@ object HelpersSpec extends Specification {
     "have the basic structure" in {
       val body = fooMultifield('_label -> "theLabel")
       body must contain("class=\"form-group")
-      body must not contain ("has-error")
+      body must not contain ("has-danger")
       body must contain("<label class=\"\">theLabel</label>")
       body must contain(testInputsString)
       body must not contain ("class=\"help-block\"")
@@ -688,7 +688,7 @@ object HelpersSpec extends Specification {
 
     "allow rendering errors" in {
       val body = multifield(fooFormWithError)(vfc, messages)
-      body must contain("has-error")
+      body must contain("has-danger")
       body must contain("<span class=\"help-block\">test-error</span>")
     }
 
@@ -730,10 +730,10 @@ object HelpersSpec extends Specification {
       testStatus("warning", withIcon = false, withFieldsArgs = true, '_warning -> true)
       testStatus("warning", withIcon = false, withFieldsArgs = false, '_warning -> "test-help")
       testStatus("warning", withIcon = false, withFieldsArgs = true, '_warning -> "test-help")
-      testStatus("error", withIcon = false, withFieldsArgs = false, '_error -> true)
-      testStatus("error", withIcon = false, withFieldsArgs = true, '_error -> true)
-      testStatus("error", withIcon = false, withFieldsArgs = false, '_error -> "test-help")
-      testStatus("error", withIcon = false, withFieldsArgs = true, '_error -> "test-help")
+      testStatus("danger", withIcon = false, withFieldsArgs = false, '_error -> true)
+      testStatus("danger", withIcon = false, withFieldsArgs = true, '_error -> true)
+      testStatus("danger", withIcon = false, withFieldsArgs = false, '_error -> "test-help")
+      testStatus("danger", withIcon = false, withFieldsArgs = true, '_error -> "test-help")
 
       "with feedback icons" in {
         testStatus("success", withIcon = true, withFieldsArgs = false, '_showIconValid -> true)
@@ -744,10 +744,10 @@ object HelpersSpec extends Specification {
         testStatus("warning", withIcon = true, withFieldsArgs = true, '_showIconWarning -> true)
         testStatus("warning", withIcon = true, withFieldsArgs = false, '_warning -> "test-help", '_showIconWarning -> true)
         testStatus("warning", withIcon = true, withFieldsArgs = true, '_warning -> "test-help", '_showIconWarning -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = false, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = true, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = false, '_error -> "test-help", '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = true, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = false, '_error -> true, '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = true, '_error -> true, '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = false, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = true, '_error -> "test-help", '_showIconOnError -> true)
       }
     }
 

--- a/play24-bootstrap4/module/test/HelpersSpec.scala
+++ b/play24-bootstrap4/module/test/HelpersSpec.scala
@@ -398,7 +398,7 @@ object HelpersSpec extends Specification {
 
     "render custom select properly" in {
       val body = b4.select(fooField, fruits, '_custom -> true).body
-      body must contain("""<select id="foo" name="foo" class="c-select">""")
+      body must contain("""<select id="foo" name="foo" class="custom-select">""")
     }
   }
 
@@ -488,51 +488,51 @@ object HelpersSpec extends Specification {
 
     "vertical: show label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(vfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
-	  	<label class="control-label">theLabel</label>
+	  <div class="form-group theClass" id="theId">
+	  	<label class="">theLabel</label>
 	  	<content>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "vertical: without label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId")(vfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
+	  <div class="form-group theClass" id="theId">
 	  	<content>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "horizontal: show label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(hfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group row theClass" id="theId">
-	  	<label class="control-label form-control-label col-md-2">theLabel</label>
+	  <div class="form-group row theClass" id="theId">
+	  	<label class="col-form-label col-md-2">theLabel</label>
 	  	<div class="col-md-10">
 	  	  <content>
 	  	</div>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "horizontal: without label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId")(hfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group row theClass" id="theId">
+	  <div class="form-group row theClass" id="theId">
 	  	<div class="col-md-10 col-md-offset-2">
 	  	  <content>
 	  	</div>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "inline: show label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(ifc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
-	  	<label class="control-label">theLabel</label>
+	  <div class="form-group theClass" id="theId">
+	  	<label class="">theLabel</label>
       <content>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "inline: without label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId")(ifc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
+	  <div class="form-group theClass" id="theId">
       <content>
-	  </fieldset>
+	  </div>
 	  """)
     }
 
@@ -657,14 +657,14 @@ object HelpersSpec extends Specification {
       val body = fooMultifield('_label -> "theLabel")
       body must contain("class=\"form-group")
       body must not contain ("has-error")
-      body must contain("<label class=\"control-label\">theLabel</label>")
+      body must contain("<label class=\"\">theLabel</label>")
       body must contain(testInputsString)
       body must not contain ("class=\"help-block\"")
     }
 
     "behave as a horizontal field constructor" in {
       val body = multifield(fooForm, Seq('_label -> "theLabel"))(hfc, messages)
-      body must contain("<label class=\"control-label form-control-label " + colLabel + "\">theLabel</label>")
+      body must contain("<label class=\"col-form-label " + colLabel + "\">theLabel</label>")
       body must contain("<div class=\"" + colInput + "\">")
     }
 
@@ -677,8 +677,8 @@ object HelpersSpec extends Specification {
     }
 
     "show label" in {
-      multifield(fooForm, Seq('_label -> "fooLabel"))(vfc, messages) must contain("<label class=\"control-label\">fooLabel</label>")
-      multifield(fooForm, Seq('_label -> "fooLabel"))(hfc, messages) must contain("<label class=\"control-label form-control-label " + colLabel + "\">fooLabel</label>")
+      multifield(fooForm, Seq('_label -> "fooLabel"))(vfc, messages) must contain("<label class=\"\">fooLabel</label>")
+      multifield(fooForm, Seq('_label -> "fooLabel"))(hfc, messages) must contain("<label class=\"col-form-label " + colLabel + "\">fooLabel</label>")
     }
 
     "without label" in {
@@ -707,7 +707,7 @@ object HelpersSpec extends Specification {
     }
 
     "render validation states" in {
-      def withStatus(status: String) = contain(s"""<fieldset class="form-group has-$status"""")
+      def withStatus(status: String) = contain(s"""<div class="form-group has-$status"""")
       def withFeedbackIcon(status: String) = contain(s""" class="form-control-$status form-control"""")
       def testStatus(status: String, withIcon: Boolean, withFieldsArgs: Boolean, args: (Symbol, Any)*) = {
         val test = if (withFieldsArgs)

--- a/play24-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
+++ b/play24-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
@@ -10,7 +10,7 @@
 <div class="my-form-group form-group @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
 	<div class="field-container">
 		@fieldInfo.labelOpt.map { label =>
-			<label class="control-label @if(fieldInfo.hideLabel){sr-only}" @if(fieldInfo.withLabelFor){for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+			<label class="@if(fieldInfo.hideLabel){sr-only}" @if(fieldInfo.withLabelFor){for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 		}
 		@inputHtml
 	</div>

--- a/play24-bootstrap4/sample/app/views/b4/my/vertical/bsFormGroup.scala.html
+++ b/play24-bootstrap4/sample/app/views/b4/my/vertical/bsFormGroup.scala.html
@@ -2,7 +2,7 @@
 <div class="my-form-group form-group @argsMap.get('_class)" id="@argsMap.get('_id)">
 	<div class="field-container">
 		@argsMap.get('_label).map { label =>
-			<label class="control-label">@bs.Args.msg(label)(messages)</label>
+			<label class="">@bs.Args.msg(label)(messages)</label>
 		}
 		@contentHtml
 	</div>

--- a/play24-bootstrap4/sample/app/views/docs.scala.html
+++ b/play24-bootstrap4/sample/app/views/docs.scala.html
@@ -358,7 +358,7 @@
 				And it will render the following if there is an error:
 			</p>
 			@code {
-				<div class="form-group has-error has-feedback" id="text_field">
+				<div class="form-group has-danger has-feedback" id="text_field">
 					<label class="" for="text">A text</label>
 					<input type="text" id="text" name="text" value="" aria-describedby="text_info_0 text_error_0" aria-invalid="true" class="form-control">
 					<span id="text_error_0" class="help-block">This field is required</span>

--- a/play24-bootstrap4/sample/app/views/docs.scala.html
+++ b/play24-bootstrap4/sample/app/views/docs.scala.html
@@ -49,7 +49,7 @@
 			</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label" for="foo">A simple text</label>
+					<label class="" for="foo">A simple text</label>
 					<input type="text" id="foo" name="foo" value="" aria-describedby="foo_info_0" class="form-control" placeholder="A simple text showing a help...">
 					<span id="foo_info_0" class="help-block">This is a help text</span>
 				</div>
@@ -67,7 +67,7 @@
 			</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label col-md-2" for="foo">A simple text</label>
+					<label class="col-md-2" for="foo">A simple text</label>
 					<div class="col-md-10">
 						<input type="text" id="foo" name="foo" value="" aria-describedby="foo_info_0" class="form-control" placeholder="A simple text showing a help...">
 						<span id="foo_info_0" class="help-block">This is a help text</span>
@@ -90,7 +90,7 @@
 			</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label sr-only" for="foo">A simple text</label>
+					<label class="sr-only" for="foo">A simple text</label>
 					<input type="text" id="foo" name="foo" value="" aria-describedby="foo_info_0" class="form-control" placeholder="A simple text showing a help...">
 					<span id="foo_info_0" class="help-block">This is a help text</span>
 				</div>
@@ -141,7 +141,7 @@
 			<p>The previous example outputs the HTML:</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label" for="foo">Constraints</label>
+					<label class="" for="foo">Constraints</label>
 					<input type="text" id="foo" name="foo" value="" class="form-control" placeholder="A simple text showing its constraints...">
 					<span class="help-block">Maximum length: 10</span>
 				</div>
@@ -359,7 +359,7 @@
 			</p>
 			@code {
 				<div class="form-group has-error has-feedback" id="text_field">
-					<label class="control-label" for="text">A text</label>
+					<label class="" for="text">A text</label>
 					<input type="text" id="text" name="text" value="" aria-describedby="text_info_0 text_error_0" aria-invalid="true" class="form-control">
 					<span id="text_error_0" class="help-block">This field is required</span>
 					<span id="text_info_0" class="help-block">Something helpful</span>

--- a/play24-bootstrap4/sample/app/views/extendIt.scala.html
+++ b/play24-bootstrap4/sample/app/views/extendIt.scala.html
@@ -102,7 +102,7 @@
 			@b4.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@mail.com" )
 		}
 	}{
-		<div class="my-form-group form-group has-error" id="foo_field">
+		<div class="my-form-group form-group has-danger" id="foo_field">
 			<div class="field-container">
 				<label class="" for="foo">Email</label>
 				<div class="input-group">

--- a/play24-bootstrap4/sample/app/views/extendIt.scala.html
+++ b/play24-bootstrap4/sample/app/views/extendIt.scala.html
@@ -104,7 +104,7 @@
 	}{
 		<div class="my-form-group form-group has-error" id="foo_field">
 			<div class="field-container">
-				<label class="control-label" for="foo">Email</label>
+				<label class="" for="foo">Email</label>
 				<div class="input-group">
 					<span class="input-group-addon">@@</span>
 					<input type="email" id="foo" name="foo" value="" aria-describedby="foo_info_0 foo_error_0" aria-invalid="true" class="form-control" placeholder="example@@mail.com">
@@ -143,7 +143,7 @@
 		<div class="my-form-group form-group @@fieldInfo.argsMap.get('_class) @@fieldInfo.status.map("has-"+_)" id="@@fieldInfo.idFormGroup">
 			<div class="field-container">
 				@@fieldInfo.labelOpt.map { label =>
-					<label class="control-label @@if(fieldInfo.hideLabel){sr-only}" @@if(fieldInfo.withLabelFor){for="@@fieldInfo.id"}>@@label</label>
+					<label class="@@if(fieldInfo.hideLabel){sr-only}" @@if(fieldInfo.withLabelFor){for="@@fieldInfo.id"}>@@label</label>
 				}
 				@@inputHtml
 			</div>

--- a/play24-bootstrap4/sample/app/views/multifield.scala.html
+++ b/play24-bootstrap4/sample/app/views/multifield.scala.html
@@ -133,7 +133,7 @@
 		
 		@code {
 			<div class="form-group" id="">
-				<label class="control-label col-md-2">Date range</label>
+				<label class="col-md-2">Date range</label>
 				<div class="col-md-10">
 					<div class="input-daterange input-group" data-date-start-date="10-11-2014">
 						<input type="text" id="dateStart" name="dateStart" value="15-11-2014" class="form-control">
@@ -215,7 +215,7 @@
 		</p>
 		@code {
 			<div class="form-group" id="">
-				<label class="control-label col-md-2">Checkboxes</label>
+				<label class="col-md-2">Checkboxes</label>
 				<div class="col-md-10">
 					<div class="multi-checkbox-list">
 						<div class="checkbox">
@@ -282,7 +282,7 @@
 		
 		@code {
 			<div class="form-group" id="">
-				<label class="control-label col-md-2">New task to do</label>
+				<label class="col-md-2">New task to do</label>
 				<div class="col-md-10">
 					<div class="input-text-checkbox input-group">
 						<span class="input-group-addon">

--- a/play25-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
@@ -3,7 +3,7 @@
 	@wrap {
 		@inputHtml
 		@fieldInfo.errorsAndInfos.map { case (id, text) =>
-			<span id="@id" class="help-block">@text</span>
+			<span id="@id" class="form-control-feedback">@text</span>
 		}
 	}
 </div>

--- a/play25-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
@@ -3,7 +3,7 @@
 	@wrap {
 		@inputHtml
 		@fieldInfo.errorsAndInfos.map { case (id, text) =>
-			<span id="@id" class="form-control-feedback">@text</span>
+			<div id="@id" class="form-control-feedback">@text</div>
 		}
 	}
 </div>

--- a/play25-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
@@ -1,9 +1,9 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html, extraClasses: Option[String] = None)(wrap: Html => Html)
-<fieldset class="form-group @extraClasses @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
+<div class="form-group @extraClasses @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
 	@wrap {
 		@inputHtml
 		@fieldInfo.errorsAndInfos.map { case (id, text) =>
 			<span id="@id" class="help-block">@text</span>
 		}
 	}
-</fieldset>
+</div>

--- a/play25-bootstrap4/module/app/views/b4/bsFormGroupCommon.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/bsFormGroupCommon.scala.html
@@ -1,11 +1,11 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(wrap: Html => Html)(implicit messages: Messages)
 @defining(argsMap.get('_id).map(_.toString).orElse(argsMap.get('id).map(_.toString + "_field"))) { idFormField =>
-	<fieldset class="form-group @argsMap.get('_class)" @idFormField.map{id=>id="@id"}>
+	<div class="form-group @argsMap.get('_class)" @idFormField.map{id=>id="@id"}>
 		@wrap {
 			@contentHtml
 			@argsMap.get('_help).map { help =>
 				<span class="help-block">@bs.Args.msg(help)(messages)</span>
 			}
 		}
-	</fieldset>
+	</div>
 }

--- a/play25-bootstrap4/module/app/views/b4/horizontal/bsFieldConstructor.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/horizontal/bsFieldConstructor.scala.html
@@ -1,7 +1,7 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html, colLabel: String, colOffset: String, colInput: String)(implicit messages: Messages)
 @b4.bsFieldConstructorCommon(fieldInfo, inputHtml, extraClasses = Some("row")) { content =>
 	@fieldInfo.labelOpt.map { label =>
-		<label class="control-label form-control-label @colLabel@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+		<label class="col-form-label @colLabel@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 		<div class="@colInput">
 			@content
 		</div>

--- a/play25-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any], colLabel: String, colOffset: String, colInput: String)(implicit messages: Messages)
 @b4.bsFormGroupCommon(contentHtml, bs.ArgsMap.withAddingStringValue(argsMap, '_class, "row")) { content =>
 	@argsMap.get('_label).map { label =>
-		<label class="control-label form-control-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="col-form-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 		<div class="@colInput">
 			@content
 		</div>

--- a/play25-bootstrap4/module/app/views/b4/horizontal/package.scala
+++ b/play25-bootstrap4/module/app/views/b4/horizontal/package.scala
@@ -27,11 +27,8 @@ package object horizontal {
    * It needs the column widths for the corresponding Bootstrap3 form-group
    */
   case class HorizontalFieldConstructor(colLabel: String, colInput: String) extends B4FieldConstructor {
-    /* The equivalent offset if label is not present (ex: colLabel = "col-md-2"  =>  colOffset = "col-md-offset-2") */
-    val colOffset: String = {
-      val chunks = colLabel.split("-")
-      (chunks.init :+ "offset" :+ chunks.last).mkString("-")
-    }
+    /* The equivalent offset if label is not present (ex: colLabel = "col-md-2"  =>  colOffset = "offset-md-2") */
+    val colOffset: String = colLabel.replace("col", "offset")
     /* Define the class of the corresponding form */
     val formClass = "form-horizontal"
     /* Renders the corresponding template of the field constructor */

--- a/play25-bootstrap4/module/app/views/b4/inline/bsFieldConstructor.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/inline/bsFieldConstructor.scala.html
@@ -1,7 +1,7 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html)(implicit messages: Messages)
 @b4.bsFieldConstructorCommon(fieldInfo, inputHtml) { content =>
 	@fieldInfo.labelOpt.map { label =>
-		<label class="control-label@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+		<label class="@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play25-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: Messages)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get('_label).map { label =>
-		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play25-bootstrap4/module/app/views/b4/package.scala
+++ b/play25-bootstrap4/module/app/views/b4/package.scala
@@ -43,7 +43,7 @@ package object b4 {
       else (false, false, isTrue(argsMap, '_showIconValid))
     }
 
-    /* The optional validation state ("success", "warning" or "error") */
+    /* The optional validation state ("success", "warning" or "danger") */
     override lazy val status: Option[String] = B4FieldInfo.status(hasErrors, argsMap)
 
     /* Indicates if any of the previous feedback icons should be shown */
@@ -76,10 +76,10 @@ package object b4 {
    * Companion object for class B4FieldInfo
    */
   object B4FieldInfo {
-    /* The optional validation state ("success", "warning" or "error") */
+    /* The optional validation state ("success", "warning" or "danger") */
     def status(hasErrors: Boolean, argsMap: Map[Symbol, Any]): Option[String] = {
       if (hasErrors)
-        Some("error")
+        Some("danger")
       else if (ArgsMap.isNotFalse(argsMap, '_warning) || isTrue(argsMap, '_showIconWarning))
         Some("warning")
       else if (ArgsMap.isNotFalse(argsMap, '_success) || isTrue(argsMap, '_showIconValid))
@@ -95,7 +95,7 @@ package object b4 {
    * - args: list of available arguments for the helper and the form-group
    */
   case class B4MultifieldInfo(fields: Seq[Field], globalArguments: Seq[(Symbol, Any)], fieldsArguments: Seq[(Symbol, Any)], override val messages: Messages) extends BSMultifieldInfo(fields, globalArguments, fieldsArguments, messages) {
-    /* The optional validation state ("success", "warning" or "error") */
+    /* The optional validation state ("success", "warning" or "danger") */
     override lazy val status: Option[String] = B4FieldInfo.status(hasErrors, argsMap)
 
     override lazy val globalArgs = {

--- a/play25-bootstrap4/module/app/views/b4/selectWithContent.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/selectWithContent.scala.html
@@ -12,7 +12,7 @@
 	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
 	val multiple = bs.ArgsMap.isTrue(argsMap, 'multiple)
-  val defaultClass = if (bs.ArgsMap.isTrue(argsMap, '_custom)) "c-select" else "form-control"
+  val defaultClass = if (bs.ArgsMap.isTrue(argsMap, '_custom)) "custom-select" else "form-control"
 	(argsMap, disabled, multiple, defaultClass)
 }) { case (argsMap, disabled, multiple, defaultClass) =>
 	@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(bs.Args.withAddingStringValue(args, 'class, defaultClass), 'disabled -> disabled)) { fieldInfo =>

--- a/play25-bootstrap4/module/app/views/b4/vertical/bsFieldConstructor.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/vertical/bsFieldConstructor.scala.html
@@ -1,7 +1,7 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html)(implicit messages: Messages)
 @b4.bsFieldConstructorCommon(fieldInfo, inputHtml) { content =>
 	@fieldInfo.labelOpt.map { label =>
-		<label class="control-label@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+		<label class="@if(fieldInfo.hideLabel){ sr-only}"@if(fieldInfo.withLabelFor){ for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play25-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
+++ b/play25-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: Messages)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get('_label).map { label =>
-		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play25-bootstrap4/module/test/FieldConstructorsSpec.scala
+++ b/play25-bootstrap4/module/test/FieldConstructorsSpec.scala
@@ -55,7 +55,7 @@ object FieldConstructorsSpec extends Specification {
 
     "have the basic structure" in {
       simpleInput must contain("class=\"form-group")
-      simpleInput must not contain ("has-error")
+      simpleInput must not contain ("has-danger")
       simpleInput must not contain ("aria-invalid")
       simpleInput must contain(testInputString)
       simpleInput must not contain ("class=\"help-block\"")
@@ -90,31 +90,31 @@ object FieldConstructorsSpec extends Specification {
 
     "allow rendering errors" in {
       val test = simpleInputWithError()
-      test must contain("has-error")
-      test must contain("<span id=\"foo_error_0\" class=\"help-block\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"help-block\">test-error-1</span>")
+      test must contain("has-danger")
+      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
+      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
     }
 
     "allow showing constraints" in {
       val test = simpleInputWithArgs('_showConstraints -> true)
-      test must contain("<span id=\"foo_info_0\" class=\"help-block\">")
-      test must contain("<span id=\"foo_info_1\" class=\"help-block\">")
-      test must contain("class=\"help-block\">" + messages("constraint.required") + "</span>")
-      test must contain("class=\"help-block\">" + messages("constraint.maxLength", 8) + "</span>")
+      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">")
+      test must contain("<span id=\"foo_info_1\" class=\"form-control-feedback\">")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.required") + "</span>")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.maxLength", 8) + "</span>")
     }
 
     "allow showing help info" in {
-      simpleInputWithArgs('_help -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_success -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_warning -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_error -> "test-help") must contain("<span id=\"foo_error_0\" class=\"help-block\">test-help</span>")
+      simpleInputWithArgs('_help -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_success -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_warning -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_error -> "test-help") must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-help</span>")
     }
 
     "allow rendering erros and hide constraints when help info is present" in {
       val test = simpleInputWithError('_showConstraints -> true, '_help -> "test-help")
-      test must contain("<span id=\"foo_error_0\" class=\"help-block\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"help-block\">test-error-1</span>")
-      test must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
+      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
+      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
+      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
       test must not contain ("<span id=\"foo_info_1\"")
     }
 
@@ -135,16 +135,16 @@ object FieldConstructorsSpec extends Specification {
       testStatus("success", withIcon = false, '_success -> "test-help")
       testStatus("warning", withIcon = false, '_warning -> true)
       testStatus("warning", withIcon = false, '_warning -> "test-help")
-      testStatus("error", withIcon = false, '_error -> true)
-      testStatus("error", withIcon = false, '_error -> "test-help")
+      testStatus("danger", withIcon = false, '_error -> true)
+      testStatus("danger", withIcon = false, '_error -> "test-help")
 
       "with feedback icons" in {
         testStatus("success", withIcon = true, '_showIconValid -> true)
         testStatus("success", withIcon = true, '_success -> "test-help", '_showIconValid -> true)
         testStatus("warning", withIcon = true, '_showIconWarning -> true)
         testStatus("warning", withIcon = true, '_warning -> "test-help", '_showIconWarning -> true)
-        testStatus("error", withIcon = true, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, '_error -> true, '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, '_error -> "test-help", '_showIconOnError -> true)
       }
     }
 

--- a/play25-bootstrap4/module/test/FieldConstructorsSpec.scala
+++ b/play25-bootstrap4/module/test/FieldConstructorsSpec.scala
@@ -91,31 +91,31 @@ object FieldConstructorsSpec extends Specification {
     "allow rendering errors" in {
       val test = simpleInputWithError()
       test must contain("has-danger")
-      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
+      test must contain("<div id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</div>")
+      test must contain("<div id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</div>")
     }
 
     "allow showing constraints" in {
       val test = simpleInputWithArgs('_showConstraints -> true)
-      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">")
-      test must contain("<span id=\"foo_info_1\" class=\"form-control-feedback\">")
-      test must contain("class=\"form-control-feedback\">" + messages("constraint.required") + "</span>")
-      test must contain("class=\"form-control-feedback\">" + messages("constraint.maxLength", 8) + "</span>")
+      test must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">")
+      test must contain("<div id=\"foo_info_1\" class=\"form-control-feedback\">")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.required") + "</div>")
+      test must contain("class=\"form-control-feedback\">" + messages("constraint.maxLength", 8) + "</div>")
     }
 
     "allow showing help info" in {
-      simpleInputWithArgs('_help -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      simpleInputWithArgs('_success -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      simpleInputWithArgs('_warning -> "test-help") must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      simpleInputWithArgs('_error -> "test-help") must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-help</span>")
+      simpleInputWithArgs('_help -> "test-help") must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      simpleInputWithArgs('_success -> "test-help") must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      simpleInputWithArgs('_warning -> "test-help") must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      simpleInputWithArgs('_error -> "test-help") must contain("<div id=\"foo_error_0\" class=\"form-control-feedback\">test-help</div>")
     }
 
     "allow rendering erros and hide constraints when help info is present" in {
       val test = simpleInputWithError('_showConstraints -> true, '_help -> "test-help")
-      test must contain("<span id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</span>")
-      test must contain("<span id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</span>")
-      test must contain("<span id=\"foo_info_0\" class=\"form-control-feedback\">test-help</span>")
-      test must not contain ("<span id=\"foo_info_1\"")
+      test must contain("<div id=\"foo_error_0\" class=\"form-control-feedback\">test-error-0</div>")
+      test must contain("<div id=\"foo_error_1\" class=\"form-control-feedback\">test-error-1</div>")
+      test must contain("<div id=\"foo_info_0\" class=\"form-control-feedback\">test-help</div>")
+      test must not contain ("<div id=\"foo_info_1\"")
     }
 
     "render validation states" in {
@@ -160,16 +160,16 @@ object FieldConstructorsSpec extends Specification {
       test1 must contain("aria-invalid=\"true\"")
       test1 must contain("aria-describedby=\"foo_status foo_info_0 foo_info_1 foo_error_0 foo_error_1\"")
       test1 must contain("<span id=\"foo_status\"")
-      test1 must contain("<span id=\"foo_info_0\"")
-      test1 must contain("<span id=\"foo_info_1\"")
-      test1 must contain("<span id=\"foo_error_0\"")
-      test1 must contain("<span id=\"foo_error_1\"")
+      test1 must contain("<div id=\"foo_info_0\"")
+      test1 must contain("<div id=\"foo_info_1\"")
+      test1 must contain("<div id=\"foo_error_0\"")
+      test1 must contain("<div id=\"foo_error_1\"")
 
       val test2 = simpleInputWithArgs('_help -> "test-help", '_showIconValid -> true)
       test2 must not contain ("aria-invalid")
       test2 must contain("aria-describedby=\"foo_status foo_info_0\"")
       test2 must contain("<span id=\"foo_status\"")
-      test2 must contain("<span id=\"foo_info_0\"")
+      test2 must contain("<div id=\"foo_info_0\"")
       test2 must not contain ("<span id=\"foo_error")
     }
   }

--- a/play25-bootstrap4/module/test/FieldConstructorsSpec.scala
+++ b/play25-bootstrap4/module/test/FieldConstructorsSpec.scala
@@ -49,7 +49,7 @@ object FieldConstructorsSpec extends Specification {
       case _ => ""
     }
     val labelExtraClasses = fc match {
-      case hfc: b4.horizontal.HorizontalFieldConstructor => " form-control-label " + hfc.colLabel
+      case hfc: b4.horizontal.HorizontalFieldConstructor => "col-form-label " + hfc.colLabel
       case _ => ""
     }
 
@@ -70,15 +70,16 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow setting extra classes form-group" in {
-      clean(simpleInputWithArgs('_class -> "extra_class another_class")) must contain(s"""<fieldset class="form-group$fieldsetExtraClasses extra_class another_class" """)
+      clean(simpleInputWithArgs('_class -> "extra_class another_class")) must contain(s"""<div class="form-group$fieldsetExtraClasses extra_class another_class" """)
     }
 
     "render the label" in {
-      clean(simpleInputWithArgs('_label -> "theLabel")) must contain(s"""<label class="control-label$labelExtraClasses" for="foo">theLabel</label>""")
+      clean(simpleInputWithArgs('_label -> "theLabel")) must contain(s"""<label class="$labelExtraClasses" for="foo">theLabel</label>""")
     }
 
     "allow hide the label" in {
-      val labelString = s"""<label class="control-label$labelExtraClasses sr-only" for="foo">theLabel</label>"""
+      val labelInner = s"${labelExtraClasses} sr-only".trim()
+      val labelString = s"""<label class="${labelInner}" for="foo">theLabel</label>"""
       clean(simpleInputWithArgs('_label -> "theLabel", '_hideLabel -> true)) must contain(labelString)
       clean(simpleInputWithArgs('_hiddenLabel -> "theLabel")) must contain(labelString)
     }
@@ -118,7 +119,7 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "render validation states" in {
-      def withStatus(status: String) = contain(s"""<fieldset class="form-group$fieldsetExtraClasses has-$status"""")
+      def withStatus(status: String) = contain(s"""<div class="form-group$fieldsetExtraClasses has-$status"""")
       def withFeedbackIcon(status: String) = contain(s""" class="form-control-$status form-control"""")
       def testStatus(status: String, withIcon: Boolean, args: (Symbol, Any)*) = {
         val test = clean(simpleInputWithArgs(args: _*))

--- a/play25-bootstrap4/module/test/HelpersSpec.scala
+++ b/play25-bootstrap4/module/test/HelpersSpec.scala
@@ -383,7 +383,7 @@ object HelpersSpec extends Specification {
 
     "render custom select properly" in {
       val body = b4.select(fooField, fruits, '_custom -> true).body
-      body must contain("""<select id="foo" name="foo" class="c-select">""")
+      body must contain("""<select id="foo" name="foo" class="custom-select">""")
     }
   }
 
@@ -473,51 +473,51 @@ object HelpersSpec extends Specification {
 
     "vertical: show label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(vfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
-	  	<label class="control-label">theLabel</label>
+	  <div class="form-group theClass" id="theId">
+	  	<label class="">theLabel</label>
 	  	<content>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "vertical: without label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId")(vfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
+	  <div class="form-group theClass" id="theId">
 	  	<content>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "horizontal: show label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(hfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group row theClass" id="theId">
-	  	<label class="control-label form-control-label col-md-2">theLabel</label>
+	  <div class="form-group row theClass" id="theId">
+	  	<label class="col-form-label col-md-2">theLabel</label>
 	  	<div class="col-md-10">
 	  	  <content>
 	  	</div>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "horizontal: without label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId")(hfc, messages) must be equalTo clean("""
-	  <fieldset class="form-group row theClass" id="theId">
-	  	<div class="col-md-10 col-md-offset-2">
+	  <div class="form-group row theClass" id="theId">
+	  	<div class="col-md-10 offset-md-2">
 	  	  <content>
 	  	</div>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "inline: show label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(ifc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
-	  	<label class="control-label">theLabel</label>
+	  <div class="form-group theClass" id="theId">
+	  	<label class="">theLabel</label>
       <content>
-	  </fieldset>
+	  </div>
 	  """)
     }
     "inline: without label" in {
       testFormGroup('_class -> "theClass", '_id -> "theId")(ifc, messages) must be equalTo clean("""
-	  <fieldset class="form-group theClass" id="theId">
+	  <div class="form-group theClass" id="theId">
       <content>
-	  </fieldset>
+	  </div>
 	  """)
     }
 
@@ -642,14 +642,14 @@ object HelpersSpec extends Specification {
       val body = fooMultifield('_label -> "theLabel")
       body must contain("class=\"form-group")
       body must not contain ("has-error")
-      body must contain("<label class=\"control-label\">theLabel</label>")
+      body must contain("<label class=\"\">theLabel</label>")
       body must contain(testInputsString)
       body must not contain ("class=\"help-block\"")
     }
 
     "behave as a horizontal field constructor" in {
       val body = multifield(fooForm, Seq('_label -> "theLabel"))(hfc, messages)
-      body must contain("<label class=\"control-label form-control-label " + colLabel + "\">theLabel</label>")
+      body must contain("<label class=\"col-form-label " + colLabel + "\">theLabel</label>")
       body must contain("<div class=\"" + colInput + "\">")
     }
 
@@ -662,8 +662,8 @@ object HelpersSpec extends Specification {
     }
 
     "show label" in {
-      multifield(fooForm, Seq('_label -> "fooLabel"))(vfc, messages) must contain("<label class=\"control-label\">fooLabel</label>")
-      multifield(fooForm, Seq('_label -> "fooLabel"))(hfc, messages) must contain("<label class=\"control-label form-control-label " + colLabel + "\">fooLabel</label>")
+      multifield(fooForm, Seq('_label -> "fooLabel"))(vfc, messages) must contain("<label class=\"\">fooLabel</label>")
+      multifield(fooForm, Seq('_label -> "fooLabel"))(hfc, messages) must contain("<label class=\"col-form-label " + colLabel + "\">fooLabel</label>")
     }
 
     "without label" in {
@@ -692,7 +692,7 @@ object HelpersSpec extends Specification {
     }
 
     "render validation states" in {
-      def withStatus(status: String) = contain(s"""<fieldset class="form-group has-$status"""")
+      def withStatus(status: String) = contain(s"""<div class="form-group has-$status"""")
       def withFeedbackIcon(status: String) = contain(s""" class="form-control-$status form-control"""")
       def testStatus(status: String, withIcon: Boolean, withFieldsArgs: Boolean, args: (Symbol, Any)*) = {
         val test = if (withFieldsArgs)

--- a/play25-bootstrap4/module/test/HelpersSpec.scala
+++ b/play25-bootstrap4/module/test/HelpersSpec.scala
@@ -641,7 +641,7 @@ object HelpersSpec extends Specification {
     "have the basic structure" in {
       val body = fooMultifield('_label -> "theLabel")
       body must contain("class=\"form-group")
-      body must not contain ("has-error")
+      body must not contain ("has-danger")
       body must contain("<label class=\"\">theLabel</label>")
       body must contain(testInputsString)
       body must not contain ("class=\"help-block\"")
@@ -673,7 +673,7 @@ object HelpersSpec extends Specification {
 
     "allow rendering errors" in {
       val body = multifield(fooFormWithError)(vfc, messages)
-      body must contain("has-error")
+      body must contain("has-danger")
       body must contain("<span class=\"help-block\">test-error</span>")
     }
 
@@ -715,10 +715,10 @@ object HelpersSpec extends Specification {
       testStatus("warning", withIcon = false, withFieldsArgs = true, '_warning -> true)
       testStatus("warning", withIcon = false, withFieldsArgs = false, '_warning -> "test-help")
       testStatus("warning", withIcon = false, withFieldsArgs = true, '_warning -> "test-help")
-      testStatus("error", withIcon = false, withFieldsArgs = false, '_error -> true)
-      testStatus("error", withIcon = false, withFieldsArgs = true, '_error -> true)
-      testStatus("error", withIcon = false, withFieldsArgs = false, '_error -> "test-help")
-      testStatus("error", withIcon = false, withFieldsArgs = true, '_error -> "test-help")
+      testStatus("danger", withIcon = false, withFieldsArgs = false, '_error -> true)
+      testStatus("danger", withIcon = false, withFieldsArgs = true, '_error -> true)
+      testStatus("danger", withIcon = false, withFieldsArgs = false, '_error -> "test-help")
+      testStatus("danger", withIcon = false, withFieldsArgs = true, '_error -> "test-help")
 
       "with feedback icons" in {
         testStatus("success", withIcon = true, withFieldsArgs = false, '_showIconValid -> true)
@@ -729,10 +729,10 @@ object HelpersSpec extends Specification {
         testStatus("warning", withIcon = true, withFieldsArgs = true, '_showIconWarning -> true)
         testStatus("warning", withIcon = true, withFieldsArgs = false, '_warning -> "test-help", '_showIconWarning -> true)
         testStatus("warning", withIcon = true, withFieldsArgs = true, '_warning -> "test-help", '_showIconWarning -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = false, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = true, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = false, '_error -> "test-help", '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = true, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = false, '_error -> true, '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = true, '_error -> true, '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = false, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("danger", withIcon = true, withFieldsArgs = true, '_error -> "test-help", '_showIconOnError -> true)
       }
     }
 

--- a/play25-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
+++ b/play25-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
@@ -10,7 +10,7 @@
 <div class="my-form-group form-group @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
 	<div class="field-container">
 		@fieldInfo.labelOpt.map { label =>
-			<label class="control-label @if(fieldInfo.hideLabel){sr-only}" @if(fieldInfo.withLabelFor){for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
+			<label class="@if(fieldInfo.hideLabel){sr-only}" @if(fieldInfo.withLabelFor){for="@fieldInfo.id"}>@bs.Args.msg(label)(messages)</label>
 		}
 		@inputHtml
 	</div>

--- a/play25-bootstrap4/sample/app/views/b4/my/vertical/bsFormGroup.scala.html
+++ b/play25-bootstrap4/sample/app/views/b4/my/vertical/bsFormGroup.scala.html
@@ -2,7 +2,7 @@
 <div class="my-form-group form-group @argsMap.get('_class)" id="@argsMap.get('_id)">
 	<div class="field-container">
 		@argsMap.get('_label).map { label =>
-			<label class="control-label">@bs.Args.msg(label)(messages)</label>
+			<label class="">@bs.Args.msg(label)(messages)</label>
 		}
 		@contentHtml
 	</div>

--- a/play25-bootstrap4/sample/app/views/docs.scala.html
+++ b/play25-bootstrap4/sample/app/views/docs.scala.html
@@ -358,7 +358,7 @@
 				And it will render the following if there is an error:
 			</p>
 			@code {
-				<div class="form-group has-error has-feedback" id="text_field">
+				<div class="form-group has-danger has-feedback" id="text_field">
 					<label class="" for="text">A text</label>
 					<input type="text" id="text" name="text" value="" aria-describedby="text_info_0 text_error_0" aria-invalid="true" class="form-control">
 					<span id="text_error_0" class="help-block">This field is required</span>

--- a/play25-bootstrap4/sample/app/views/docs.scala.html
+++ b/play25-bootstrap4/sample/app/views/docs.scala.html
@@ -49,7 +49,7 @@
 			</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label" for="foo">A simple text</label>
+					<label class="" for="foo">A simple text</label>
 					<input type="text" id="foo" name="foo" value="" aria-describedby="foo_info_0" class="form-control" placeholder="A simple text showing a help...">
 					<span id="foo_info_0" class="help-block">This is a help text</span>
 				</div>
@@ -67,7 +67,7 @@
 			</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label col-md-2" for="foo">A simple text</label>
+					<label class="col-md-2" for="foo">A simple text</label>
 					<div class="col-md-10">
 						<input type="text" id="foo" name="foo" value="" aria-describedby="foo_info_0" class="form-control" placeholder="A simple text showing a help...">
 						<span id="foo_info_0" class="help-block">This is a help text</span>
@@ -90,7 +90,7 @@
 			</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label sr-only" for="foo">A simple text</label>
+					<label class="sr-only" for="foo">A simple text</label>
 					<input type="text" id="foo" name="foo" value="" aria-describedby="foo_info_0" class="form-control" placeholder="A simple text showing a help...">
 					<span id="foo_info_0" class="help-block">This is a help text</span>
 				</div>
@@ -141,7 +141,7 @@
 			<p>The previous example outputs the HTML:</p>
 			@code {
 				<div class="form-group" id="foo_field">
-					<label class="control-label" for="foo">Constraints</label>
+					<label class="" for="foo">Constraints</label>
 					<input type="text" id="foo" name="foo" value="" class="form-control" placeholder="A simple text showing its constraints...">
 					<span class="help-block">Maximum length: 10</span>
 				</div>
@@ -359,7 +359,7 @@
 			</p>
 			@code {
 				<div class="form-group has-error has-feedback" id="text_field">
-					<label class="control-label" for="text">A text</label>
+					<label class="" for="text">A text</label>
 					<input type="text" id="text" name="text" value="" aria-describedby="text_info_0 text_error_0" aria-invalid="true" class="form-control">
 					<span id="text_error_0" class="help-block">This field is required</span>
 					<span id="text_info_0" class="help-block">Something helpful</span>

--- a/play25-bootstrap4/sample/app/views/extendIt.scala.html
+++ b/play25-bootstrap4/sample/app/views/extendIt.scala.html
@@ -102,7 +102,7 @@
 			@b4.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@mail.com" )
 		}
 	}{
-		<div class="my-form-group form-group has-error" id="foo_field">
+		<div class="my-form-group form-group has-danger" id="foo_field">
 			<div class="field-container">
 				<label class="" for="foo">Email</label>
 				<div class="input-group">

--- a/play25-bootstrap4/sample/app/views/extendIt.scala.html
+++ b/play25-bootstrap4/sample/app/views/extendIt.scala.html
@@ -104,7 +104,7 @@
 	}{
 		<div class="my-form-group form-group has-error" id="foo_field">
 			<div class="field-container">
-				<label class="control-label" for="foo">Email</label>
+				<label class="" for="foo">Email</label>
 				<div class="input-group">
 					<span class="input-group-addon">@@</span>
 					<input type="email" id="foo" name="foo" value="" aria-describedby="foo_info_0 foo_error_0" aria-invalid="true" class="form-control" placeholder="example@@mail.com">
@@ -143,7 +143,7 @@
 		<div class="my-form-group form-group @@fieldInfo.argsMap.get('_class) @@fieldInfo.status.map("has-"+_)" id="@@fieldInfo.idFormGroup">
 			<div class="field-container">
 				@@fieldInfo.labelOpt.map { label =>
-					<label class="control-label @@if(fieldInfo.hideLabel){sr-only}" @@if(fieldInfo.withLabelFor){for="@@fieldInfo.id"}>@@label</label>
+					<label class="@@if(fieldInfo.hideLabel){sr-only}" @@if(fieldInfo.withLabelFor){for="@@fieldInfo.id"}>@@label</label>
 				}
 				@@inputHtml
 			</div>

--- a/play25-bootstrap4/sample/app/views/multifield.scala.html
+++ b/play25-bootstrap4/sample/app/views/multifield.scala.html
@@ -133,7 +133,7 @@
 		
 		@code {
 			<div class="form-group" id="">
-				<label class="control-label col-md-2">Date range</label>
+				<label class="col-md-2">Date range</label>
 				<div class="col-md-10">
 					<div class="input-daterange input-group" data-date-start-date="10-11-2014">
 						<input type="text" id="dateStart" name="dateStart" value="15-11-2014" class="form-control">
@@ -215,7 +215,7 @@
 		</p>
 		@code {
 			<div class="form-group" id="">
-				<label class="control-label col-md-2">Checkboxes</label>
+				<label class="col-md-2">Checkboxes</label>
 				<div class="col-md-10">
 					<div class="multi-checkbox-list">
 						<div class="checkbox">
@@ -282,7 +282,7 @@
 		
 		@code {
 			<div class="form-group" id="">
-				<label class="control-label col-md-2">New task to do</label>
+				<label class="col-md-2">New task to do</label>
 				<div class="col-md-10">
 					<div class="input-text-checkbox input-group">
 						<span class="input-group-addon">


### PR DESCRIPTION
I just downloaded b4alpha3 to play with it and upon trying to use play-bootstrap it seems:
-- control-label goes away
-- form-control-label becomes col-form-label
-- form-group need to be div instead of fieldset (fieldset is for grouping multiple inputs?)
