### PR TITLE
New b3.hidden should also work with PlayJava's play.data.Field

### DIFF
--- a/play24-bootstrap3/module/app/views/b3/package.scala
+++ b/play24-bootstrap3/module/app/views/b3/package.scala
@@ -194,7 +194,7 @@ package object b3 {
   def url(field: Field, args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, messages: Messages) = inputType("url", field, args: _*)(fc, messages)
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, messages: Messages) = inputType("week", field, args: _*)(fc, messages)
 
-  def hidden(name: Any, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
+  def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
   def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B3FieldInfo] => Html)(implicit fc: B3FieldConstructor, messages: Messages) = radioWithContent(field, args: _*)(content)(fc, messages)

--- a/play24-bootstrap4/module/app/views/b4/package.scala
+++ b/play24-bootstrap4/module/app/views/b4/package.scala
@@ -191,7 +191,7 @@ package object b4 {
   def url(field: Field, args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, messages: Messages) = inputType("url", field, args: _*)(fc, messages)
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, messages: Messages) = inputType("week", field, args: _*)(fc, messages)
 
-  def hidden(name: Any, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
+  def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
   def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B4FieldInfo] => Html)(implicit fc: B4FieldConstructor, messages: Messages) = radioWithContent(field, args: _*)(content)(fc, messages)

--- a/play25-bootstrap3/module/app/views/b3/package.scala
+++ b/play25-bootstrap3/module/app/views/b3/package.scala
@@ -194,7 +194,7 @@ package object b3 {
   def url(field: Field, args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, messages: Messages) = inputType("url", field, args: _*)(fc, messages)
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, messages: Messages) = inputType("week", field, args: _*)(fc, messages)
 
-  def hidden(name: Any, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
+  def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
   def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B3FieldInfo] => Html)(implicit fc: B3FieldConstructor, messages: Messages) = radioWithContent(field, args: _*)(content)(fc, messages)

--- a/play25-bootstrap4/module/app/views/b4/package.scala
+++ b/play25-bootstrap4/module/app/views/b4/package.scala
@@ -191,7 +191,7 @@ package object b4 {
   def url(field: Field, args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, messages: Messages) = inputType("url", field, args: _*)(fc, messages)
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, messages: Messages) = inputType("week", field, args: _*)(fc, messages)
 
-  def hidden(name: Any, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
+  def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
   def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B4FieldInfo] => Html)(implicit fc: B4FieldConstructor, messages: Messages) = radioWithContent(field, args: _*)(content)(fc, messages)

--- a/play26-bootstrap3/module/app/views/b3/package.scala
+++ b/play26-bootstrap3/module/app/views/b3/package.scala
@@ -194,7 +194,7 @@ package object b3 {
   def url(field: Field, args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = inputType("url", field, args: _*)(fc, msgsProv)
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = inputType("week", field, args: _*)(fc, msgsProv)
 
-  def hidden(name: Any, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
+  def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
   def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B3FieldInfo] => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = radioWithContent(field, args: _*)(content)(fc, msgsProv)

--- a/play26-bootstrap4/module/app/views/b4/package.scala
+++ b/play26-bootstrap4/module/app/views/b4/package.scala
@@ -191,7 +191,7 @@ package object b4 {
   def url(field: Field, args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = inputType("url", field, args: _*)(fc, msgsProv)
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = inputType("week", field, args: _*)(fc, msgsProv)
 
-  def hidden(name: Any, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
+  def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
   def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B4FieldInfo] => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = radioWithContent(field, args: _*)(content)(fc, msgsProv)


### PR DESCRIPTION
Having
```
@b3.hidden(myForm("somefield"), 'class -> "something")
```

does work when `myForm("somefield")` is a `play.`**`api`**`.data.Field` :+1: 

But when `myForm("somefield")` is a `play.data.Field` (when using PlayJava instead of PlayScala) then the result is broken :-1: :
```
<input type="hidden" name="Form.Field(somefield)" value="(&#x27;class,something)" >
```
That's because of the signatures of the `hidden` method:
```
def hidden(name: Any, value: Any, args: (Symbol, Any)*) ...
def hidden(field: Field, args: (Symbol, Any)*) ...
```
For `play.api.data.Field` the correct method will be called of course.
But for `play.data.Field` the method with the `Any` method will be called instead because it fits best (Usually `play.data.Field` will be implicitly converted to `play.api.data.Field` but this doesn't count here).

So the best thing I thought is to just change the `Any` param to `String` so that `play.data.Field` will now be implictly converted to `play.api.data.Field` and then the correct method will be called. Another approach would be that we introduce a third method like `def hidden(field: play.data.Field, args: (Symbol, Any)*) ...` but the "problem" is that play-bootstrap is based on PlayScala so `play.data.Field` is not available here...

@adrianhurt What do you think?