### PR TITLE
Make filters provided

### DIFF
--- a/play25-bootstrap3/module/build.sbt
+++ b/play25-bootstrap3/module/build.sbt
@@ -12,7 +12,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  filters,
+  filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.1.2-P25-SNAPSHOT",
   "org.webjars" % "bootstrap" % "3.3.7-1" exclude("org.webjars", "jquery"),
   "org.webjars" % "jquery" % "3.2.1",

--- a/play25-bootstrap4/module/build.sbt
+++ b/play25-bootstrap4/module/build.sbt
@@ -12,7 +12,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  filters,
+  filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.1.2-P25-SNAPSHOT",
   "org.webjars" % "bootstrap" % "4.0.0-alpha.6-1" exclude("org.webjars", "jquery"),
   "org.webjars" % "jquery" % "3.2.1",

--- a/play26-bootstrap3/module/build.sbt
+++ b/play26-bootstrap3/module/build.sbt
@@ -12,7 +12,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  filters,
+  filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.1.2-P26-SNAPSHOT",
   "org.webjars" % "bootstrap" % "3.3.7-1" exclude("org.webjars", "jquery"),
   "org.webjars" % "jquery" % "3.2.1",

--- a/play26-bootstrap4/module/build.sbt
+++ b/play26-bootstrap4/module/build.sbt
@@ -12,7 +12,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  filters,
+  filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.1.2-P26-SNAPSHOT",
   "org.webjars" % "bootstrap" % "4.0.0-alpha.6-1" exclude("org.webjars", "jquery"),
   "org.webjars" % "jquery" % "3.2.1",


### PR DESCRIPTION
We should make the `filters` dependency provided. Because if you **never** use `@b3.formCSRF`, `@b3.vertical.formCSRF`, etc. then you don't need the `filters` in your project.
E.g. Imagine you have a project where you don't use any filter at all and also don't use  `@b3.formCSRF`, etc. you still would have added the filters as dependencies. Bad.

The documentation already tells the user to setup csrf when using the b3 csrf tags:
http://adrianhurt.github.io/play-bootstrap/1.1.1-P25-B3/docs/#forms-csrf
> Be sure you implement your project correctly for CSRF support as it is explained at the Play's documentation.

This should be enough explanation.

PS:
I didn't added "provided" for the Play 2.4 `build.sbt` because all the `package.scala` in `play24-bootstrap{3,4}/module/app/views/b{3,4}/{clear,vertical,inline,horizontal}/package.scala` depend on `implicit token: play.filters.csrf.CSRF.Token` so the whole library wouldn't work at all for users of Play 2.4.