### PR TITLE
Disable PlayFilters autoplugin for Play 2.6

### DIFF
--- a/core-play26/build.sbt
+++ b/core-play26/build.sbt
@@ -9,7 +9,7 @@ crossScalaVersions := Seq("2.12.2", "2.11.8")
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
 
 
 

--- a/play26-bootstrap3/module/build.sbt
+++ b/play26-bootstrap3/module/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   specs2 % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
 
 
 

--- a/play26-bootstrap4/module/build.sbt
+++ b/play26-bootstrap4/module/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   specs2 % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
 
 
 


### PR DESCRIPTION
Turns out that #89 is not enough to disable filters.
Have a look at [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26#Disabling-Default-Filters):
> If you want to remove **all filter classes**, you can disable it through the disablePlugins mechanism:
> `lazy val root = project.in(file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)`

What does this solve?
If I have a project that depends on play-bootstrap and want to disable the filters in my project via `.disablePlugins(PlayFilters)` the filters would still be enabled because they are enabled in play-bootstrap...