### PR TITLE
Update to Play 2.6.12

### DIFF
--- a/core-play26/project/plugins.sbt
+++ b/core-play26/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 // web plugins
 

--- a/play26-bootstrap3/module/project/plugins.sbt
+++ b/play26-bootstrap3/module/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 // web plugins
 

--- a/play26-bootstrap3/sample/project/plugins.sbt
+++ b/play26-bootstrap3/sample/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 // web plugins
 

--- a/play26-bootstrap4/module/project/plugins.sbt
+++ b/play26-bootstrap4/module/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 // web plugins
 

--- a/play26-bootstrap4/sample/project/plugins.sbt
+++ b/play26-bootstrap4/sample/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 // web plugins
 


### PR DESCRIPTION
The newest Play release also fixes a problem with twirl which also affects play-bootstrap:
https://github.com/playframework/twirl/pull/169

This means we should see less new lines in the rendered html :tada: 