### PR TITLE
multifield: adjust example to code

### DIFF
--- a/versions/1.4-P26-B4/multifield.html
+++ b/versions/1.4-P26-B4/multifield.html
@@ -208,9 +208,9 @@ tab: multifield
     <code>b4/multiCheckbox.scala.html</code> within our <code>views</code> folder with the following code:
   </p>
   <div class="highlight">
-<pre><code>@(fieldsWithArgs: (Field, Seq[(Symbol,Any)])*)(globalArgs: (Symbol,Any)*)(implicit fc: b4.BSFieldConstructor, messages: Messages)
+<pre><code>@(fieldsWithArgs: (Field, Seq[(Symbol,Any)])*)(globalArgs: (Symbol,Any)*)(implicit fc: b4.B4FieldConstructor, messages: Messages)
 @b4.multifield(fieldsWithArgs.map(_._1):_*)(globalArgs, fieldsWithArgs.map(_._2).flatten) { implicit cfc =&gt;
-  &lt;div @toHtmlArgs(b4.Args.inner(globalArgs).toMap)&gt;
+  &lt;div @toHtmlArgs(bs.Args.inner(globalArgs).toMap)&gt;
     @fieldsWithArgs.map { case (field, fieldArgs) =&gt;
       @b4.checkbox(field, fieldArgs:_*)
     }


### PR DESCRIPTION
This patch solves the following problem.

```
[error] [...]/app/views/b4/multiCheckbox.scala.html:1:91: type BSFieldConstructor is not a member of package views.html.b4
[error] @(fieldsWithArgs: (Field, Seq[(Symbol,Any)])*)(globalArgs: (Symbol,Any)*)(implicit fc: b4.BSFieldConstructor, messages: Messages)
[error]                                                                                           ^
[error] [...]/app/views/b4/multiCheckbox.scala.html:3:25: object Args is not a member of package views.html.b4
[error]     <div @toHtmlArgs(b4.Args.inner(globalArgs).toMap)>
[error]                         ^
```

There are two problems with this patch.

1. I am new to both, Scala and the play framework, so this might be completely wrong.
2. There are several examples on your web site where the code is used and all of them should be fixed, if this is the correct solution.