### PR TITLE
Scala 2.13 + use Play's own translate method to preserve raw Html

### DIFF
--- a/core-play27/app/views/bs/Args.scala
+++ b/core-play27/app/views/bs/Args.scala
@@ -18,6 +18,7 @@ package views.html.bs
 object Args {
 
   import play.api.i18n.MessagesProvider
+  import play.api.templates.PlayMagic.translate
 
   /**
    * Adds some default arguments to the parameter 'args'
@@ -66,18 +67,12 @@ object Args {
   /**
    * Localizes an argument
    */
-  def msg(arg: (Symbol, Any))(implicit msgsProv: MessagesProvider): (Symbol, Any) = arg match {
-    case (sym, str: String) => (sym, msgsProv.messages(str))
-    case _                  => arg
-  }
+  def msg(arg: (Symbol, Any))(implicit msgsProv: MessagesProvider): (Symbol, Any) = (arg._1, translate(arg._2)(msgsProv))
 
   /**
    * Localizes a value
    */
-  def msg(a: Any)(implicit msgsProv: MessagesProvider): Any = a match {
-    case str: String => msgsProv.messages(str)
-    case _           => a
-  }
+  def msg(a: Any)(implicit msgsProv: MessagesProvider): Any = translate(a)(msgsProv)
 }
 
 object ArgsMap {

--- a/core-play27/app/views/bs/package.scala
+++ b/core-play27/app/views/bs/package.scala
@@ -20,8 +20,8 @@ package object bs {
   import play.api.data.{ Field, FormError }
   import play.twirl.api.Html
   import play.api.i18n.MessagesProvider
+  import play.api.templates.PlayMagic.translate
   import bs.ArgsMap.isTrue
-  import play.api.mvc.Call
 
   /**
    * Class with relevant variables for a field to pass it to the helper and field constructor
@@ -76,12 +76,12 @@ package object bs {
     def errors(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[String] = {
       argsMap.get('_error).filter(!_.isInstanceOf[Boolean]).map {
         _ match {
-          case Some(FormError(_, message, args)) => Seq(msgsProv.messages(message, args.map(a => translateMsgArg(a, msgsProv)): _*))
+          case Some(FormError(_, message, args)) => Seq(msgsProv.messages(message, args.map(a => translate(a)(msgsProv)): _*))
           case message                           => Seq(msgsProv.messages(message.toString))
         }
       }.getOrElse {
         maybeField.filter(_ => argsMap.get('_showErrors) != Some(false)).map { field =>
-          field.errors.map { e => msgsProv.messages(e.message, e.args.map(a => translateMsgArg(a, msgsProv)): _*) }
+          field.errors.map { e => msgsProv.messages(e.message, e.args.map(a => translate(a)(msgsProv)): _*) }
         }.getOrElse(Nil)
       }
     }
@@ -97,7 +97,7 @@ package object bs {
     def helpInfos(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[String] = {
       argsMap.get('_help).map(m => Seq(msgsProv.messages(m.toString))).getOrElse {
         maybeField.filter(_ => argsMap.get('_showConstraints) == Some(true)).map { field =>
-          field.constraints.map(c => msgsProv.messages(c._1, c._2.map(a => translateMsgArg(a, msgsProv)): _*)) ++ field.format.map(f => msgsProv.messages(f._1, f._2.map(a => translateMsgArg(a, msgsProv)): _*))
+          field.constraints.map(c => msgsProv.messages(c._1, c._2.map(a => translate(a)(msgsProv)): _*)) ++ field.format.map(f => msgsProv.messages(f._1, f._2.map(a => translate(a)(msgsProv)): _*))
         }.getOrElse(Nil)
       }
     }
@@ -128,12 +128,6 @@ package object bs {
       }
       case _ => None
     }.flatten
-
-    private def translateMsgArg(msgArg: Any, msgsProv: MessagesProvider) = msgArg match {
-      case key: String  => msgsProv.messages(key)
-      case keys: Seq[_] => keys.map(key => msgsProv.messages(key.toString))
-      case _            => msgArg
-    }
   }
 
   /**

--- a/core-play27/app/views/bs/package.scala
+++ b/core-play27/app/views/bs/package.scala
@@ -51,7 +51,7 @@ package object bs {
     val value: Option[String] = field.value.orElse(argsMap.get('value).map(_.toString))
 
     /* List with every error and its corresponding ARIA id. Ex: ("foo_error_0" -> "foo error")  */
-    val errors: Seq[(String, String)] = BSFieldInfo.errors(Some(field), argsMap, msgsProv).zipWithIndex.map {
+    val errors: Seq[(String, Any)] = BSFieldInfo.errors(Some(field), argsMap, msgsProv).zipWithIndex.map {
       case (error, i) => (id + "_error_" + i, error)
     }
 
@@ -73,7 +73,7 @@ package object bs {
     }
 
     /* List with every error */
-    def errors(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[String] = {
+    def errors(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
       argsMap.get('_error).filter(!_.isInstanceOf[Boolean]).map {
         _ match {
           case Some(FormError(_, message, args)) => Seq(msgsProv.messages(message, args.map(a => translate(a)(msgsProv)): _*))
@@ -87,14 +87,14 @@ package object bs {
     }
 
     /* List with every "feedback info" except "errors" */
-    def feedbackInfosButErrors(argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[String] = {
+    def feedbackInfosButErrors(argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
       argsMap.get('_warning).filter(!_.isInstanceOf[Boolean]).map(m => Seq(msgsProv.messages(m.toString))).getOrElse(
         argsMap.get('_success).filter(!_.isInstanceOf[Boolean]).map(m => Seq(msgsProv.messages(m.toString))).getOrElse(Nil)
       )
     }
 
     /* List with every "help info", i.e. a help text or constraints */
-    def helpInfos(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[String] = {
+    def helpInfos(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
       argsMap.get('_help).map(m => Seq(msgsProv.messages(m.toString))).getOrElse {
         maybeField.filter(_ => argsMap.get('_showConstraints) == Some(true)).map { field =>
           field.constraints.map(c => msgsProv.messages(c._1, c._2.map(a => translate(a)(msgsProv)): _*)) ++ field.format.map(f => msgsProv.messages(f._1, f._2.map(a => translate(a)(msgsProv)): _*))
@@ -142,7 +142,7 @@ package object bs {
     val argsMap: Map[Symbol, Any] = Args.withoutNones(fieldsArguments ++ globalArguments).toMap
 
     /* List with every error */
-    val errors: Seq[String] = {
+    val errors: Seq[Any] = {
       val globalErrors = BSFieldInfo.errors(None, argsMap, msgsProv)
       if (globalErrors.size > 0)
         globalErrors

--- a/core-play27/app/views/bs/package.scala
+++ b/core-play27/app/views/bs/package.scala
@@ -77,7 +77,8 @@ package object bs {
       argsMap.get('_error).filter(!_.isInstanceOf[Boolean]).map {
         _ match {
           case Some(FormError(_, message, args)) => Seq(msgsProv.messages(message, args.map(a => translate(a)(msgsProv)): _*))
-          case message                           => Seq(msgsProv.messages(message.toString))
+          case FormError(_, message, args)       => Seq(msgsProv.messages(message, args.map(a => translate(a)(msgsProv)): _*))
+          case message                           => Seq(translate(message)(msgsProv))
         }
       }.getOrElse {
         maybeField.filter(_ => argsMap.get('_showErrors) != Some(false)).map { field =>
@@ -88,14 +89,14 @@ package object bs {
 
     /* List with every "feedback info" except "errors" */
     def feedbackInfosButErrors(argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
-      argsMap.get('_warning).filter(!_.isInstanceOf[Boolean]).map(m => Seq(msgsProv.messages(m.toString))).getOrElse(
-        argsMap.get('_success).filter(!_.isInstanceOf[Boolean]).map(m => Seq(msgsProv.messages(m.toString))).getOrElse(Nil)
+      argsMap.get('_warning).filter(!_.isInstanceOf[Boolean]).map(m => Seq(translate(m)(msgsProv))).getOrElse(
+        argsMap.get('_success).filter(!_.isInstanceOf[Boolean]).map(m => Seq(translate(m)(msgsProv))).getOrElse(Nil)
       )
     }
 
     /* List with every "help info", i.e. a help text or constraints */
     def helpInfos(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
-      argsMap.get('_help).map(m => Seq(msgsProv.messages(m.toString))).getOrElse {
+      argsMap.get('_help).map(m => Seq(translate(m)(msgsProv))).getOrElse {
         maybeField.filter(_ => argsMap.get('_showConstraints) == Some(true)).map { field =>
           field.constraints.map(c => msgsProv.messages(c._1, c._2.map(a => translate(a)(msgsProv)): _*)) ++ field.format.map(f => msgsProv.messages(f._1, f._2.map(a => translate(a)(msgsProv)): _*))
         }.getOrElse(Nil)

--- a/core-play27/build.sbt
+++ b/core-play27/build.sbt
@@ -4,9 +4,9 @@ name := """play-bootstrap-core"""
 
 version := "1.5-P27-SNAPSHOT"
 
-scalaVersion := "2.13.0-M5"
+scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.13.0-M5", "2.12.8")
+crossScalaVersions := Seq("2.13.0", "2.12.8")
 
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 

--- a/core-play27/project/plugins.sbt
+++ b/core-play27/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 
 // web plugins
 

--- a/play27-bootstrap3/module/app/views/b3/package.scala
+++ b/play27-bootstrap3/module/app/views/b3/package.scala
@@ -33,7 +33,7 @@ package object b3 {
   case class B3FieldInfo(field: Field, withFeedback: Boolean, withLabelFor: Boolean, args: Seq[(Symbol, Any)], override val msgsProv: MessagesProvider) extends BSFieldInfo(field, args, msgsProv) {
 
     /* List with every "info" and its corresponding ARIA id. Ex: ("foo_info_0" -> "foo constraint")  */
-    val infos: Seq[(String, String)] = {
+    val infos: Seq[(String, Any)] = {
       val feedbackInfosButErrors = BSFieldInfo.feedbackInfosButErrors(argsMap, msgsProv).zipWithIndex.map {
         case (info, i) => (id + "_info_" + i, info)
       }
@@ -127,7 +127,7 @@ package object b3 {
   case class B3MultifieldInfo(fields: Seq[Field], globalArguments: Seq[(Symbol, Any)], fieldsArguments: Seq[(Symbol, Any)], override val msgsProv: MessagesProvider) extends BSMultifieldInfo(fields, globalArguments, fieldsArguments, msgsProv) {
 
     /* List with every "info" */
-    val infos: Seq[String] = {
+    val infos: Seq[Any] = {
       val globalFeedbackInfosButErrors = BSFieldInfo.feedbackInfosButErrors(argsMap, msgsProv)
       if (globalFeedbackInfosButErrors.size > 0)
         globalFeedbackInfosButErrors
@@ -144,7 +144,7 @@ package object b3 {
     }
 
     /* List with the errors and infos */
-    def errorsAndInfos: Seq[String] = errors ++ infos
+    def errorsAndInfos: Seq[Any] = errors ++ infos
 
     /* The optional validation state ("success", "warning" or "error") */
     override lazy val status: Option[String] = B3FieldInfo.status(hasErrors, argsMap)

--- a/play27-bootstrap3/module/build.sbt
+++ b/play27-bootstrap3/module/build.sbt
@@ -4,9 +4,9 @@ name := """play-bootstrap"""
 
 version := "1.5-P27-B3-SNAPSHOT"
 
-scalaVersion := "2.13.0-M5"
+scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.13.0-M5", "2.12.8")
+crossScalaVersions := Seq("2.13.0", "2.12.8")
 
 resolvers ++= Seq(
   "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",

--- a/play27-bootstrap3/module/project/plugins.sbt
+++ b/play27-bootstrap3/module/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 
 // web plugins
 

--- a/play27-bootstrap3/sample/build.sbt
+++ b/play27-bootstrap3/sample/build.sbt
@@ -4,7 +4,7 @@ name := """play-bootstrap-sample"""
 
 version := "1.5"
 
-scalaVersion := "2.13.0-M5"
+scalaVersion := "2.13.0"
 
 routesGenerator := InjectedRoutesGenerator
 

--- a/play27-bootstrap3/sample/project/plugins.sbt
+++ b/play27-bootstrap3/sample/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 
 // web plugins
 

--- a/play27-bootstrap4/module/app/views/b4/package.scala
+++ b/play27-bootstrap4/module/app/views/b4/package.scala
@@ -32,7 +32,7 @@ package object b4 {
   case class B4FieldInfo(field: Field, withLabelFor: Boolean, args: Seq[(Symbol, Any)], override val msgsProv: MessagesProvider) extends BSFieldInfo(field, args, msgsProv) {
 
     /* List with every "feedback info" and its corresponding ARIA id. Ex: ("foo_info_0" -> "foo constraint")  */
-    val feedbackInfos: Seq[(String, String)] =
+    val feedbackInfos: Seq[(String, Any)] =
       if (errors.size > 0)
         errors
       else
@@ -41,7 +41,7 @@ package object b4 {
         }
 
     /* List with every "help info" (i.e. a help text or constraints) and its corresponding ARIA id. Ex: ("foo_info_0" -> "foo constraint")  */
-    val helpInfos: Seq[(String, String)] = BSFieldInfo.helpInfos(Some(field), argsMap, msgsProv).zipWithIndex.map {
+    val helpInfos: Seq[(String, Any)] = BSFieldInfo.helpInfos(Some(field), argsMap, msgsProv).zipWithIndex.map {
       case (info, i) => (id + "_info_" + i, info)
     }
 
@@ -109,7 +109,7 @@ package object b4 {
   case class B4MultifieldInfo(fields: Seq[Field], globalArguments: Seq[(Symbol, Any)], fieldsArguments: Seq[(Symbol, Any)], override val msgsProv: MessagesProvider) extends BSMultifieldInfo(fields, globalArguments, fieldsArguments, msgsProv) {
 
     /* List with every "feedback info"  */
-    val feedbackInfos: Seq[String] = {
+    val feedbackInfos: Seq[Any] = {
       if (errors.size > 0)
         errors
       else
@@ -117,7 +117,7 @@ package object b4 {
     }
 
     /* List with every "help info" (i.e. a help text or constraints) */
-    val helpInfos: Seq[String] = {
+    val helpInfos: Seq[Any] = {
       val globalHelpInfos = BSFieldInfo.helpInfos(None, argsMap, msgsProv)
       if (globalHelpInfos.size > 0)
         globalHelpInfos

--- a/play27-bootstrap4/module/build.sbt
+++ b/play27-bootstrap4/module/build.sbt
@@ -4,9 +4,9 @@ name := """play-bootstrap"""
 
 version := "1.5-P27-B4-SNAPSHOT"
 
-scalaVersion := "2.13.0-M5"
+scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.13.0-M5", "2.12.8")
+crossScalaVersions := Seq("2.13.0", "2.12.8")
 
 resolvers ++= Seq(
   "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",

--- a/play27-bootstrap4/module/project/plugins.sbt
+++ b/play27-bootstrap4/module/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 
 // web plugins
 

--- a/play27-bootstrap4/sample/build.sbt
+++ b/play27-bootstrap4/sample/build.sbt
@@ -4,7 +4,7 @@ name := """play-bootstrap-sample"""
 
 version := "1.5"
 
-scalaVersion := "2.13.0-M5"
+scalaVersion := "2.13.0"
 
 routesGenerator := InjectedRoutesGenerator
 

--- a/play27-bootstrap4/sample/project/plugins.sbt
+++ b/play27-bootstrap4/sample/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 
 // web plugins
 


### PR DESCRIPTION
Upgrades to Play 2.7.3 and Scala 2.13.

Also, Play 2.7.3 introduces a `translate` method, which we can use instead of `translateMsgArg`:
https://github.com/playframework/playframework/pull/9385

Why should we use this method?
Because this `translate` method preserves raw Html as raw Html. This is important if someone passes `Html("<b>hi</b>")` to a field e.g. to us this as label. In such a case a user clearly expresses the (s)he wants to use raw html. However right now in such cases we use `.toString` which does not preserve raw html... There was a bug report: https://github.com/playframework/playframework/issues/9361
So now some methods use/return `Any` instead of `String` because the type can also be twirl's `Html`.