### PR TITLE
Remove deprecated Symbol literal

### DIFF
--- a/core-play27/app/views/bs/package.scala
+++ b/core-play27/app/views/bs/package.scala
@@ -33,22 +33,22 @@ package object bs {
     val argsMap: Map[Symbol, Any] = Args.withoutNones(args).toMap
 
     /* Id of the input */
-    val id: String = argsMap.get('id).map(_.toString).getOrElse(field.id)
+    val id: String = argsMap.get(Symbol("id")).map(_.toString).getOrElse(field.id)
 
     /* Id of the form-group */
-    val idFormField: String = argsMap.get('_id).map(_.toString).getOrElse(id + "_field")
+    val idFormField: String = argsMap.get(Symbol("_id")).map(_.toString).getOrElse(id + "_field")
 
     /* The optional label */
-    val labelOpt: Option[Any] = argsMap.get('_label).orElse(argsMap.get('_hiddenLabel))
+    val labelOpt: Option[Any] = argsMap.get(Symbol("_label")).orElse(argsMap.get(Symbol("_hiddenLabel")))
 
     /* Indicates if the label must be hidden */
-    val hideLabel: Boolean = isTrue(argsMap, '_hideLabel) || argsMap.contains('_hiddenLabel)
+    val hideLabel: Boolean = isTrue(argsMap, Symbol("_hideLabel")) || argsMap.contains(Symbol("_hiddenLabel"))
 
     /* Name of the input */
     def name: String = field.name
 
     /* Value of the input */
-    val value: Option[String] = field.value.orElse(argsMap.get('value).map(_.toString))
+    val value: Option[String] = field.value.orElse(argsMap.get(Symbol("value")).map(_.toString))
 
     /* List with every error and its corresponding ARIA id. Ex: ("foo_error_0" -> "foo error")  */
     val errors: Seq[(String, Any)] = BSFieldInfo.errors(Some(field), argsMap, msgsProv).zipWithIndex.map {
@@ -56,7 +56,7 @@ package object bs {
     }
 
     /* Indicates if there is any error */
-    val hasErrors: Boolean = !errors.isEmpty || ArgsMap.isNotFalse(argsMap, '_error)
+    val hasErrors: Boolean = !errors.isEmpty || ArgsMap.isNotFalse(argsMap, Symbol("_error"))
 
     /* The optional validation state ("success", "warning" or "error") */
     lazy val status: Option[String] = BSFieldInfo.status(hasErrors, argsMap)
@@ -74,14 +74,14 @@ package object bs {
 
     /* List with every error */
     def errors(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
-      argsMap.get('_error).filter(!_.isInstanceOf[Boolean]).map {
+      argsMap.get(Symbol("_error")).filter(!_.isInstanceOf[Boolean]).map {
         _ match {
           case Some(FormError(_, message, args)) => Seq(msgsProv.messages(message, args.map(a => translate(a)(msgsProv)): _*))
           case FormError(_, message, args)       => Seq(msgsProv.messages(message, args.map(a => translate(a)(msgsProv)): _*))
           case message                           => Seq(translate(message)(msgsProv))
         }
       }.getOrElse {
-        maybeField.filter(_ => argsMap.get('_showErrors) != Some(false)).map { field =>
+        maybeField.filter(_ => argsMap.get(Symbol("_showErrors")) != Some(false)).map { field =>
           field.errors.map { e => msgsProv.messages(e.message, e.args.map(a => translate(a)(msgsProv)): _*) }
         }.getOrElse(Nil)
       }
@@ -89,15 +89,15 @@ package object bs {
 
     /* List with every "feedback info" except "errors" */
     def feedbackInfosButErrors(argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
-      argsMap.get('_warning).filter(!_.isInstanceOf[Boolean]).map(m => Seq(translate(m)(msgsProv))).getOrElse(
-        argsMap.get('_success).filter(!_.isInstanceOf[Boolean]).map(m => Seq(translate(m)(msgsProv))).getOrElse(Nil)
+      argsMap.get(Symbol("_warning")).filter(!_.isInstanceOf[Boolean]).map(m => Seq(translate(m)(msgsProv))).getOrElse(
+        argsMap.get(Symbol("_success")).filter(!_.isInstanceOf[Boolean]).map(m => Seq(translate(m)(msgsProv))).getOrElse(Nil)
       )
     }
 
     /* List with every "help info", i.e. a help text or constraints */
     def helpInfos(maybeField: Option[Field], argsMap: Map[Symbol, Any], msgsProv: MessagesProvider): Seq[Any] = {
-      argsMap.get('_help).map(m => Seq(translate(m)(msgsProv))).getOrElse {
-        maybeField.filter(_ => argsMap.get('_showConstraints) == Some(true)).map { field =>
+      argsMap.get(Symbol("_help")).map(m => Seq(translate(m)(msgsProv))).getOrElse {
+        maybeField.filter(_ => argsMap.get(Symbol("_showConstraints")) == Some(true)).map { field =>
           field.constraints.map(c => msgsProv.messages(c._1, c._2.map(a => translate(a)(msgsProv)): _*)) ++ field.format.map(f => msgsProv.messages(f._1, f._2.map(a => translate(a)(msgsProv)): _*))
         }.getOrElse(Nil)
       }
@@ -107,9 +107,9 @@ package object bs {
     def status(hasErrors: Boolean, argsMap: Map[Symbol, Any]): Option[String] = {
       if (hasErrors)
         Some("error")
-      else if (ArgsMap.isNotFalse(argsMap, '_warning))
+      else if (ArgsMap.isNotFalse(argsMap, Symbol("_warning")))
         Some("warning")
-      else if (ArgsMap.isNotFalse(argsMap, '_success))
+      else if (ArgsMap.isNotFalse(argsMap, Symbol("_success")))
         Some("success")
       else
         None
@@ -117,14 +117,14 @@ package object bs {
 
     /* Generates automatically the input attributes for the constraints of a field */
     def constraintsArgs(field: Field, msgsProv: MessagesProvider): Seq[(Symbol, Any)] = field.constraints.map {
-      case ("constraint.required", params)            => Some(('required -> true))
-      case ("constraint.min", params: Seq[Any])       => Some(('min -> msgsProv.messages(params.head.toString)))
-      case ("constraint.max", params: Seq[Any])       => Some(('max -> msgsProv.messages(params.head.toString)))
-      case ("constraint.minLength", params: Seq[Any]) => Some(('minlength -> msgsProv.messages(params.head.toString)))
-      case ("constraint.maxLength", params: Seq[Any]) => Some(('maxlength -> msgsProv.messages(params.head.toString)))
+      case ("constraint.required", params)            => Some((Symbol("required") -> true))
+      case ("constraint.min", params: Seq[Any])       => Some((Symbol("min") -> msgsProv.messages(params.head.toString)))
+      case ("constraint.max", params: Seq[Any])       => Some((Symbol("max") -> msgsProv.messages(params.head.toString)))
+      case ("constraint.minLength", params: Seq[Any]) => Some((Symbol("minlength") -> msgsProv.messages(params.head.toString)))
+      case ("constraint.maxLength", params: Seq[Any]) => Some((Symbol("maxlength") -> msgsProv.messages(params.head.toString)))
       case ("constraint.pattern", params: Seq[Any]) => params.head match {
-        case str: String        => Some(('pattern -> msgsProv.messages(str)))
-        case func: Function0[_] => Some(('pattern -> msgsProv.messages(func.asInstanceOf[() => scala.util.matching.Regex]().toString)))
+        case str: String        => Some((Symbol("pattern") -> msgsProv.messages(str)))
+        case func: Function0[_] => Some((Symbol("pattern") -> msgsProv.messages(func.asInstanceOf[() => scala.util.matching.Regex]().toString)))
         case _                  => None
       }
       case _ => None
@@ -154,7 +154,7 @@ package object bs {
     }
 
     /* Indicates if there is any error */
-    val hasErrors: Boolean = !errors.isEmpty || ArgsMap.isNotFalse(argsMap, '_error)
+    val hasErrors: Boolean = !errors.isEmpty || ArgsMap.isNotFalse(argsMap, Symbol("_error"))
 
     /* The optional validation state ("success", "warning" or "error") */
     lazy val status: Option[String] = BSFieldInfo.status(hasErrors, argsMap)

--- a/play27-bootstrap3/module/app/views/b3/bsFieldConstructorCommon.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/bsFieldConstructorCommon.scala.html
@@ -1,5 +1,5 @@
 @(fieldInfo: b3.B3FieldInfo, inputHtml: Html)(wrap: Html => Html)(implicit fc: b3.B3FieldConstructor)
-<div class="form-group @fieldInfo.argsMap.get('_class) @fieldInfo.statusWithFeedback" id="@fieldInfo.idFormField">
+<div class="form-group @fieldInfo.argsMap.get(Symbol("_class")) @fieldInfo.statusWithFeedback" id="@fieldInfo.idFormField">
 	@wrap {
 		@inputHtml
 		@fieldInfo.errorsAndInfos.map { case (id, text) =>

--- a/play27-bootstrap3/module/app/views/b3/bsFormGroupCommon.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/bsFormGroupCommon.scala.html
@@ -1,9 +1,9 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(wrap: Html => Html)(implicit messages: MessagesProvider)
-@defining(argsMap.get('_id).map(_.toString).orElse(argsMap.get('id).map(_.toString + "_field"))) { idFormField =>
-	<div class="form-group @argsMap.get('_class)" @idFormField.map{id=>id="@id"}>
+@defining(argsMap.get(Symbol("_id")).map(_.toString).orElse(argsMap.get(Symbol("id")).map(_.toString + "_field"))) { idFormField =>
+	<div class="form-group @argsMap.get(Symbol("_class"))" @idFormField.map{id=>id="@id"}>
 		@wrap {
 			@contentHtml
-			@argsMap.get('_help).map { help =>
+			@argsMap.get(Symbol("_help")).map { help =>
 				<span class="help-block">@bs.Args.msg(help)(messages)</span>
 			}
 		}

--- a/play27-bootstrap3/module/app/views/b3/checkbox.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/checkbox.scala.html
@@ -8,7 +8,7 @@
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
 	(argsMap, value, checked, containsReadonly, readonly, disabled)
 }){ case (argsMap, value, checked, containsReadonly, readonly, disabled) =>
-	@inputFormGroup(field, withFeedback = false, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == 'checked), 'checked -> checked, 'disabled -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withFeedback = false, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == 'checked), Symbol("checked") -> checked, Symbol("disabled") -> disabled)) { fieldInfo =>
 		<div class="checkbox@if(containsReadonly){ checkbox-group}@if(disabled){ disabled}">
 			<label for="@fieldInfo.id">
 				<input type="checkbox" id="@fieldInfo.id" name="@fieldInfo.name" value="@value" @toHtmlArgs(fieldInfo.innerArgsMap)>

--- a/play27-bootstrap3/module/app/views/b3/checkbox.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/checkbox.scala.html
@@ -1,8 +1,8 @@
 @(field: Field, args: (Symbol,Any)*)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
 @defining({
 	val argsMap = args.toMap
-	val value = argsMap.get('value).getOrElse("true").toString
-	val checked = argsMap.get('checked).orElse(field.value.map(_ == value).orElse(argsMap.get('_default))).map(_.toString == "true").getOrElse(false)
+	val value = argsMap.get(Symbol("value")).getOrElse("true").toString
+	val checked = argsMap.get(Symbol("checked")).orElse(field.value.map(_ == value).orElse(argsMap.get(Symbol("_default")))).map(_.toString == "true").getOrElse(false)
 	val containsReadonly = argsMap.contains('readonly)
 	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
@@ -12,7 +12,7 @@
 		<div class="checkbox@if(containsReadonly){ checkbox-group}@if(disabled){ disabled}">
 			<label for="@fieldInfo.id">
 				<input type="checkbox" id="@fieldInfo.id" name="@fieldInfo.name" value="@value" @toHtmlArgs(fieldInfo.innerArgsMap)>
-				@argsMap.get('_text).map(bs.Args.msg(_)(messages))
+				@argsMap.get(Symbol("_text")).map(bs.Args.msg(_)(messages))
 			</label>
 			@if(containsReadonly) {
 				<input type="hidden" name="@fieldInfo.name" value="@{fieldInfo.value.getOrElse(if (checked) value else "")}"@if(!disabled){ disabled}/>

--- a/play27-bootstrap3/module/app/views/b3/checkbox.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/checkbox.scala.html
@@ -3,12 +3,12 @@
 	val argsMap = args.toMap
 	val value = argsMap.get(Symbol("value")).getOrElse("true").toString
 	val checked = argsMap.get(Symbol("checked")).orElse(field.value.map(_ == value).orElse(argsMap.get(Symbol("_default")))).map(_.toString == "true").getOrElse(false)
-	val containsReadonly = argsMap.contains('readonly)
-	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
-	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
+	val containsReadonly = argsMap.contains(Symbol("readonly"))
+	val readonly = bs.ArgsMap.isTrue(argsMap, Symbol("readonly"))
+	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, Symbol("disabled"))
 	(argsMap, value, checked, containsReadonly, readonly, disabled)
 }){ case (argsMap, value, checked, containsReadonly, readonly, disabled) =>
-	@inputFormGroup(field, withFeedback = false, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == 'checked), Symbol("checked") -> checked, Symbol("disabled") -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withFeedback = false, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == Symbol("checked")), Symbol("checked") -> checked, Symbol("disabled") -> disabled)) { fieldInfo =>
 		<div class="checkbox@if(containsReadonly){ checkbox-group}@if(disabled){ disabled}">
 			<label for="@fieldInfo.id">
 				<input type="checkbox" id="@fieldInfo.id" name="@fieldInfo.name" value="@value" @toHtmlArgs(fieldInfo.innerArgsMap)>

--- a/play27-bootstrap3/module/app/views/b3/clear/package.scala
+++ b/play27-bootstrap3/module/app/views/b3/clear/package.scala
@@ -55,11 +55,11 @@ package object clear {
    * *********************************************************************************************************************************
    */
   def form(action: Call, args: (Symbol, Any)*)(body: ClearFieldConstructor => Html) = {
-    val cfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, '_feedbackIcons))
+    val cfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, Symbol("_feedbackIcons")))
     views.html.b3.form(action, inner(args): _*)(body(cfc))(cfc)
   }
   def formCSRF(action: Call, args: (Symbol, Any)*)(body: ClearFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val cfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, '_feedbackIcons))
+    val cfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, Symbol("_feedbackIcons")))
     views.html.b3.formCSRF(action, inner(args): _*)(body(cfc))(cfc, request)
   }
 

--- a/play27-bootstrap3/module/app/views/b3/form.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/form.scala.html
@@ -1,4 +1,4 @@
 @(action: Call, args: (Symbol, Any)*)(body: => Html)(implicit fc: b3.B3FieldConstructor)
-<form action="@action.toString" method="@action.method" class="@fc.formClass @bs.Args.get(args, 'class)" @toHtmlArgs(bs.Args.remove(bs.Args.inner(args, 'role -> "form"), 'class).toMap)>
+<form action="@action.toString" method="@action.method" class="@fc.formClass @bs.Args.get(args, 'class)" @toHtmlArgs(bs.Args.remove(bs.Args.inner(args, Symbol("role") -> "form"), 'class).toMap)>
 	@body
 </form>

--- a/play27-bootstrap3/module/app/views/b3/form.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/form.scala.html
@@ -1,4 +1,4 @@
 @(action: Call, args: (Symbol, Any)*)(body: => Html)(implicit fc: b3.B3FieldConstructor)
-<form action="@action.toString" method="@action.method" class="@fc.formClass @bs.Args.get(args, 'class)" @toHtmlArgs(bs.Args.remove(bs.Args.inner(args, Symbol("role") -> "form"), 'class).toMap)>
+<form action="@action.toString" method="@action.method" class="@fc.formClass @bs.Args.get(args, Symbol("class"))" @toHtmlArgs(bs.Args.remove(bs.Args.inner(args, Symbol("role") -> "form"), Symbol("class")).toMap)>
 	@body
 </form>

--- a/play27-bootstrap3/module/app/views/b3/horizontal/bsFormGroup.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/horizontal/bsFormGroup.scala.html
@@ -1,6 +1,6 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any], colLabel: String, colOffset: String, colInput: String)(implicit messages: MessagesProvider)
 @b3.bsFormGroupCommon(contentHtml, argsMap) { content =>
-	@argsMap.get('_label).map { label =>
+	@argsMap.get(Symbol("_label")).map { label =>
 		<label class="control-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 		<div class="@colInput">
 			@content

--- a/play27-bootstrap3/module/app/views/b3/horizontal/bsFormGroup.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/horizontal/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any], colLabel: String, colOffset: String, colInput: String)(implicit messages: MessagesProvider)
 @b3.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get(Symbol("_label")).map { label =>
-		<label class="control-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="control-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, Symbol("_hideLabel"))){ sr-only}">@bs.Args.msg(label)(messages)</label>
 		<div class="@colInput">
 			@content
 		</div>

--- a/play27-bootstrap3/module/app/views/b3/horizontal/package.scala
+++ b/play27-bootstrap3/module/app/views/b3/horizontal/package.scala
@@ -61,11 +61,11 @@ package object horizontal {
    * *********************************************************************************************************************************
    */
   def form(action: Call, colLabel: String, colInput: String, args: (Symbol, Any)*)(body: HorizontalFieldConstructor => Html) = {
-    val hfc = fieldConstructorSpecific(colLabel, colInput, withFeedbackIcons = isTrue(args, '_feedbackIcons))
+    val hfc = fieldConstructorSpecific(colLabel, colInput, withFeedbackIcons = isTrue(args, Symbol("_feedbackIcons")))
     views.html.b3.form(action, inner(args): _*)(body(hfc))(hfc)
   }
   def formCSRF(action: Call, colLabel: String, colInput: String, args: (Symbol, Any)*)(body: HorizontalFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val hfc = fieldConstructorSpecific(colLabel, colInput, withFeedbackIcons = isTrue(args, '_feedbackIcons))
+    val hfc = fieldConstructorSpecific(colLabel, colInput, withFeedbackIcons = isTrue(args, Symbol("_feedbackIcons")))
     views.html.b3.formCSRF(action, inner(args): _*)(body(hfc))(hfc, request)
   }
 

--- a/play27-bootstrap3/module/app/views/b3/inline/bsFormGroup.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/inline/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: MessagesProvider)
 @b3.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get(Symbol("_label")).map { label =>
-		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, Symbol("_hideLabel"))){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play27-bootstrap3/module/app/views/b3/inline/bsFormGroup.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/inline/bsFormGroup.scala.html
@@ -1,6 +1,6 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: MessagesProvider)
 @b3.bsFormGroupCommon(contentHtml, argsMap) { content =>
-	@argsMap.get('_label).map { label =>
+	@argsMap.get(Symbol("_label")).map { label =>
 		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content

--- a/play27-bootstrap3/module/app/views/b3/inline/package.scala
+++ b/play27-bootstrap3/module/app/views/b3/inline/package.scala
@@ -55,11 +55,11 @@ package object inline {
    * *********************************************************************************************************************************
    */
   def form(action: Call, args: (Symbol, Any)*)(body: InlineFieldConstructor => Html) = {
-    val ifc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, '_feedbackTooltip))
+    val ifc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b3.form(action, inner(args): _*)(body(ifc))(ifc)
   }
   def formCSRF(action: Call, args: (Symbol, Any)*)(body: InlineFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val ifc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, '_feedbackTooltip))
+    val ifc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b3.formCSRF(action, inner(args): _*)(body(ifc))(ifc, request)
   }
 

--- a/play27-bootstrap3/module/app/views/b3/inputWrapped.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/inputWrapped.scala.html
@@ -1,5 +1,5 @@
 @(inputType: String, field: Field, args: (Symbol,Any)*)(inputGroup: Html => Html)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
-@inputFormGroup(field, withFeedback = true, withLabelFor = true, bs.Args.withAddingStringValue(args, 'class, "form-control")) { fieldInfo =>
+@inputFormGroup(field, withFeedback = true, withLabelFor = true, bs.Args.withAddingStringValue(args, Symbol("class"), "form-control")) { fieldInfo =>
 	@inputGroup {
 	    <input type="@inputType" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(fieldInfo.innerArgsMap)>
 		@if(fieldInfo.hasFeedback) {

--- a/play27-bootstrap3/module/app/views/b3/package.scala
+++ b/play27-bootstrap3/module/app/views/b3/package.scala
@@ -92,7 +92,7 @@ package object b3 {
       Args.inner(
         Args.remove(args, Symbol("id"), Symbol("value")).map {
           case arg if arg._1 == Symbol("placeholder") => Args.msg(arg)(msgsProv.messages)
-          case other                         => other
+          case other                                  => other
         }
       )
     ).toMap

--- a/play27-bootstrap3/module/app/views/b3/package.scala
+++ b/play27-bootstrap3/module/app/views/b3/package.scala
@@ -54,9 +54,9 @@ package object b3 {
     /* Each boolean indicate if a any of the corresponding feedback icons should be shown */
     val (showIconError, showIconWarning, showIconValid) = {
       if (!withFeedback) (false, false, false)
-      else if (hasErrors) (isTrue(argsMap, '_showIconOnError), false, false)
-      else if (isTrue(argsMap, '_showIconWarning)) (false, true, false)
-      else (false, false, isTrue(argsMap, '_showIconValid))
+      else if (hasErrors) (isTrue(argsMap, Symbol("_showIconOnError")), false, false)
+      else if (isTrue(argsMap, Symbol("_showIconWarning"))) (false, true, false)
+      else (false, false, isTrue(argsMap, Symbol("_showIconValid")))
     }
 
     /* Indicates if any of the previous feedback icons should be shown */
@@ -90,8 +90,8 @@ package object b3 {
       (if (hasErrors) Seq(Symbol("aria-invalid") -> "true") else Nil) ++
       BSFieldInfo.constraintsArgs(field, msgsProv) ++
       Args.inner(
-        Args.remove(args, 'id, 'value).map {
-          case arg if arg._1 == 'placeholder => Args.msg(arg)(msgsProv.messages)
+        Args.remove(args, Symbol("id"), Symbol("value")).map {
+          case arg if arg._1 == Symbol("placeholder") => Args.msg(arg)(msgsProv.messages)
           case other                         => other
         }
       )
@@ -106,9 +106,9 @@ package object b3 {
     def status(hasErrors: Boolean, argsMap: Map[Symbol, Any]): Option[String] = {
       if (hasErrors)
         Some("error")
-      else if (ArgsMap.isNotFalse(argsMap, '_warning) || isTrue(argsMap, '_showIconWarning))
+      else if (ArgsMap.isNotFalse(argsMap, Symbol("_warning")) || isTrue(argsMap, Symbol("_showIconWarning")))
         Some("warning")
-      else if (ArgsMap.isNotFalse(argsMap, '_success) || isTrue(argsMap, '_showIconValid))
+      else if (ArgsMap.isNotFalse(argsMap, Symbol("_success")) || isTrue(argsMap, Symbol("_showIconValid")))
         Some("success")
       else
         None
@@ -150,11 +150,11 @@ package object b3 {
     override lazy val status: Option[String] = B3FieldInfo.status(hasErrors, argsMap)
 
     /* The optional validation state for the form-group ("has-success", "has-warning", "has-error") with the optional "has-feedback" */
-    def statusWithFeedback: Option[String] = B3FieldInfo.statusWithFeedback(status, hasFeedback = isTrue(argsMap, '_hasFeedback))
+    def statusWithFeedback: Option[String] = B3FieldInfo.statusWithFeedback(status, hasFeedback = isTrue(argsMap, Symbol("_hasFeedback")))
 
     override lazy val globalArgs = {
-      val withoutHelp = Args.remove(globalArguments, '_help)
-      val withStatus = status.map(s => Args.withDefault(withoutHelp, '_class -> statusWithFeedback)).getOrElse(withoutHelp)
+      val withoutHelp = Args.remove(globalArguments, Symbol("_help"))
+      val withStatus = status.map(s => Args.withDefault(withoutHelp, Symbol("_class") -> statusWithFeedback)).getOrElse(withoutHelp)
       withStatus
     }
   }
@@ -213,7 +213,7 @@ package object b3 {
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = inputType("week", field, args: _*)(fc, msgsProv)
 
   def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
-  def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
+  def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, Symbol("value"))), (bs.Args.inner(bs.Args.remove(args, Symbol("value")))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B3FieldInfo] => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = radioWithContent(field, args: _*)(content)(fc, msgsProv)
   def radio(field: Field, options: Seq[(String, Any)], args: (Symbol, Any)*)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = radioWithOptions(field, options, args: _*)(fc, msgsProv)
@@ -226,8 +226,8 @@ package object b3 {
   def button(args: (Symbol, Any)*)(text: => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = buttonType("button", args: _*)(text)(fc, msgsProv)
 
   def static(args: (Symbol, Any)*)(text: => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = staticBasic(args: _*)(text)(fc, msgsProv)
-  def static(label: String, args: (Symbol, Any)*)(text: => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, '_label -> label): _*)(text)(fc, msgsProv)
-  def static(label: Html, args: (Symbol, Any)*)(text: => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, '_label -> label): _*)(text)(fc, msgsProv)
+  def static(label: String, args: (Symbol, Any)*)(text: => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, Symbol("_label") -> label): _*)(text)(fc, msgsProv)
+  def static(label: Html, args: (Symbol, Any)*)(text: => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, Symbol("_label") -> label): _*)(text)(fc, msgsProv)
 
   def free(args: (Symbol, Any)*)(content: => Html)(implicit fc: B3FieldConstructor, msgsProv: MessagesProvider) = freeFormGroup(args)(_ => content)(fc, msgsProv)
 }

--- a/play27-bootstrap3/module/app/views/b3/radioWithContent.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/radioWithContent.scala.html
@@ -14,7 +14,7 @@
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
 	(argsMap, inline, disabled)
 }) { case (argsMap, inline, disabled) =>
-	@inputFormGroup(field, withFeedback = false, withLabelFor = false, bs.Args.withDefault(args, 'disabled -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withFeedback = false, withLabelFor = false, bs.Args.withDefault(args, Symbol("disabled") -> disabled)) { fieldInfo =>
 		@readonlyWrapper(fieldInfo.name, fieldInfo.value, argsMap, disabled) {
       		@content(inline, disabled, fieldInfo)
 		}

--- a/play27-bootstrap3/module/app/views/b3/radioWithContent.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/radioWithContent.scala.html
@@ -1,6 +1,6 @@
 @(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, b3.B3FieldInfo] => Html)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
 @readonlyWrapper(name: String, value: Option[String], argsMap: Map[Symbol, Any], disabled: Boolean)(contentWrapped: Html) = {
-	@if(argsMap.contains('readonly)) {
+	@if(argsMap.contains(Symbol("readonly"))) {
 		<div class="radio-group">
 			@contentWrapped
 			<input type="hidden" name="@name" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
@@ -9,9 +9,9 @@
 }
 @defining({
 	val argsMap = args.toMap
-	val inline = bs.ArgsMap.isTrue(argsMap, '_inline) || fc.formClass == "form-inline"
-	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
-	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
+	val inline = bs.ArgsMap.isTrue(argsMap, Symbol("_inline")) || fc.formClass == "form-inline"
+	val readonly = bs.ArgsMap.isTrue(argsMap, Symbol("readonly"))
+	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, Symbol("disabled"))
 	(argsMap, inline, disabled)
 }) { case (argsMap, inline, disabled) =>
 	@inputFormGroup(field, withFeedback = false, withLabelFor = false, bs.Args.withDefault(args, Symbol("disabled") -> disabled)) { fieldInfo =>

--- a/play27-bootstrap3/module/app/views/b3/radioWithContent.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/radioWithContent.scala.html
@@ -3,7 +3,7 @@
 	@if(argsMap.contains('readonly)) {
 		<div class="radio-group">
 			@contentWrapped
-			<input type="hidden" name="@name" value="@{value.orElse(argsMap.get('_hiddenValue)).get}"@if(!disabled){ disabled}/>
+			<input type="hidden" name="@name" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
 		</div>
 	} else { @contentWrapped }
 }

--- a/play27-bootstrap3/module/app/views/b3/radioWithOptions.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/radioWithOptions.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, options: Seq[(String, Any)], args: (Symbol, Any)*)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
-@radioWithContent(field, bs.Args.withDefault(args, '_hiddenValue -> options.headOption.map(_._1)):_*) { implicit extraInfo =>
+@radioWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> options.headOption.map(_._1)):_*) { implicit extraInfo =>
 	@options.map { v =>
 		@radioOption(v._1, v._2)
 	}

--- a/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
@@ -14,7 +14,7 @@
 	val multiple = bs.ArgsMap.isTrue(argsMap, Symbol("multiple"))
 	(argsMap, disabled, multiple)
 }) { case (argsMap, disabled, multiple) =>
-	@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(bs.Args.withAddingStringValue(args, 'class, "form-control"), Symbol("disabled") -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(bs.Args.withAddingStringValue(args, Symbol("class"), "form-control"), Symbol("disabled") -> disabled)) { fieldInfo =>
 		@defining( if(multiple) "%s[]".format(fieldInfo.name) else fieldInfo.name ) { selectName =>
 			@defining( ( !field.indexes.isEmpty && multiple ) match {
 				case true => field.indexes.map( i => field("[%s]".format(i)).value ).flatten.toSet

--- a/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
@@ -3,7 +3,7 @@
 	@if(argsMap.contains('readonly)) {
 		<div class="select-group">
 			@contentWrapped
-			<input type="hidden" name="@selectName" value="@{value.orElse(argsMap.get('_hiddenValue)).get}"@if(!disabled){ disabled}/>
+			<input type="hidden" name="@selectName" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
 		</div>
 	} else { @contentWrapped }
 }
@@ -23,7 +23,7 @@
 			}){ implicit values =>
 				@readonlyWrapper(selectName, fieldInfo.value, disabled, argsMap) {
 					<select id="@fieldInfo.id" name="@selectName" @toHtmlArgs(fieldInfo.innerArgsMap)>
-						@argsMap.get('_default).map { v =>
+						@argsMap.get(Symbol("_default")).map { v =>
 							@selectOption("", v, Symbol("class") -> "blank", Symbol("selected") -> true, Symbol("disabled") -> "disabled")
 						}
 						@content(values)

--- a/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
@@ -1,6 +1,6 @@
 @(field: Field, args: (Symbol,Any)*)(content: Set[String] => Html)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
 @readonlyWrapper(selectName: String, value: Option[String], disabled: Boolean, argsMap: Map[Symbol, Any])(contentWrapped: Html) = {
-	@if(argsMap.contains('readonly)) {
+	@if(argsMap.contains(Symbol("readonly"))) {
 		<div class="select-group">
 			@contentWrapped
 			<input type="hidden" name="@selectName" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
@@ -9,9 +9,9 @@
 }
 @defining({
 	val argsMap = args.toMap
-	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
-	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
-	val multiple = bs.ArgsMap.isTrue(argsMap, 'multiple)
+	val readonly = bs.ArgsMap.isTrue(argsMap, Symbol("readonly"))
+	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, Symbol("disabled"))
+	val multiple = bs.ArgsMap.isTrue(argsMap, Symbol("multiple"))
 	(argsMap, disabled, multiple)
 }) { case (argsMap, disabled, multiple) =>
 	@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(bs.Args.withAddingStringValue(args, 'class, "form-control"), Symbol("disabled") -> disabled)) { fieldInfo =>

--- a/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/selectWithContent.scala.html
@@ -14,7 +14,7 @@
 	val multiple = bs.ArgsMap.isTrue(argsMap, 'multiple)
 	(argsMap, disabled, multiple)
 }) { case (argsMap, disabled, multiple) =>
-	@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(bs.Args.withAddingStringValue(args, 'class, "form-control"), 'disabled -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(bs.Args.withAddingStringValue(args, 'class, "form-control"), Symbol("disabled") -> disabled)) { fieldInfo =>
 		@defining( if(multiple) "%s[]".format(fieldInfo.name) else fieldInfo.name ) { selectName =>
 			@defining( ( !field.indexes.isEmpty && multiple ) match {
 				case true => field.indexes.map( i => field("[%s]".format(i)).value ).flatten.toSet
@@ -24,7 +24,7 @@
 				@readonlyWrapper(selectName, fieldInfo.value, disabled, argsMap) {
 					<select id="@fieldInfo.id" name="@selectName" @toHtmlArgs(fieldInfo.innerArgsMap)>
 						@argsMap.get('_default).map { v =>
-							@selectOption("", v, 'class -> "blank", 'selected -> true, 'disabled -> "disabled")
+							@selectOption("", v, Symbol("class") -> "blank", Symbol("selected") -> true, Symbol("disabled") -> "disabled")
 						}
 						@content(values)
 					</select>

--- a/play27-bootstrap3/module/app/views/b3/selectWithOptions.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/selectWithOptions.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
-@selectWithContent(field, bs.Args.withDefault(args, '_hiddenValue -> bs.Args.get(args, '_default).orElse(options.headOption.map(_._1))):_*) { implicit values =>
+@selectWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> bs.Args.get(args, '_default).orElse(options.headOption.map(_._1))):_*) { implicit values =>
 	@options.map { v =>
 		@selectOption(v._1, v._2)
 	}

--- a/play27-bootstrap3/module/app/views/b3/selectWithOptions.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/selectWithOptions.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
-@selectWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> bs.Args.get(args, '_default).orElse(options.headOption.map(_._1))):_*) { implicit values =>
+@selectWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> bs.Args.get(args, Symbol("_default")).orElse(options.headOption.map(_._1))):_*) { implicit values =>
 	@options.map { v =>
 		@selectOption(v._1, v._2)
 	}

--- a/play27-bootstrap3/module/app/views/b3/staticBasic.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/staticBasic.scala.html
@@ -1,4 +1,4 @@
 @(args: (Symbol,Any)*)(text: => Html)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
-@freeFormGroup(bs.Args.withAddingStringValue(args, 'class, "form-control-static")) { innerArgsMap =>
+@freeFormGroup(bs.Args.withAddingStringValue(args, Symbol("class"), "form-control-static")) { innerArgsMap =>
 	<p @toHtmlArgs(innerArgsMap)>@text</p>
 }(fc, messages)

--- a/play27-bootstrap3/module/app/views/b3/textarea.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/textarea.scala.html
@@ -1,4 +1,4 @@
 @(field: Field, args: (Symbol,Any)*)(implicit fc: b3.B3FieldConstructor, messages: MessagesProvider)
-@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withAddingStringValue(args, 'class, "form-control")) { fieldInfo =>
+@inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withAddingStringValue(args, Symbol("class"), "form-control")) { fieldInfo =>
     <textarea id="@fieldInfo.id" name="@fieldInfo.name" @toHtmlArgs(fieldInfo.innerArgsMap)>@fieldInfo.value</textarea>
 }(fc, messages)

--- a/play27-bootstrap3/module/app/views/b3/vertical/bsFormGroup.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/vertical/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: MessagesProvider)
 @b3.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get(Symbol("_label")).map { label =>
-		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
+		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, Symbol("_hideLabel"))){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content
 }

--- a/play27-bootstrap3/module/app/views/b3/vertical/bsFormGroup.scala.html
+++ b/play27-bootstrap3/module/app/views/b3/vertical/bsFormGroup.scala.html
@@ -1,6 +1,6 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit messages: MessagesProvider)
 @b3.bsFormGroupCommon(contentHtml, argsMap) { content =>
-	@argsMap.get('_label).map { label =>
+	@argsMap.get(Symbol("_label")).map { label =>
 		<label class="control-label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(messages)</label>
 	}
 	@content

--- a/play27-bootstrap3/module/app/views/b3/vertical/package.scala
+++ b/play27-bootstrap3/module/app/views/b3/vertical/package.scala
@@ -55,11 +55,11 @@ package object vertical {
    * *********************************************************************************************************************************
    */
   def form(action: Call, args: (Symbol, Any)*)(body: VerticalFieldConstructor => Html) = {
-    val vfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, '_feedbackIcons))
+    val vfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, Symbol("_feedbackIcons")))
     views.html.b3.form(action, args: _*)(body(vfc))(vfc)
   }
   def formCSRF(action: Call, args: (Symbol, Any)*)(body: VerticalFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val vfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, '_feedbackIcons))
+    val vfc = fieldConstructorSpecific(withFeedbackIcons = isTrue(args, Symbol("_feedbackIcons")))
     views.html.b3.formCSRF(action, args: _*)(body(vfc))(vfc, request)
   }
 

--- a/play27-bootstrap3/module/test/FieldConstructorsSpec.scala
+++ b/play27-bootstrap3/module/test/FieldConstructorsSpec.scala
@@ -68,21 +68,21 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow setting a custom id" in {
-      simpleInputWithArgs('_id -> "customid") must contain("id=\"customid\"")
+      simpleInputWithArgs(Symbol("_id") -> "customid") must contain("id=\"customid\"")
     }
 
     "allow setting extra classes form-group" in {
-      clean(simpleInputWithArgs('_class -> "extra_class another_class")) must contain(s"""<div class="form-group extra_class another_class" """)
+      clean(simpleInputWithArgs(Symbol("_class") -> "extra_class another_class")) must contain(s"""<div class="form-group extra_class another_class" """)
     }
 
     "render the label" in {
-      clean(simpleInputWithArgs('_label -> "theLabel")) must contain(s"""<label class="control-label$labelExtraClasses" for="foo">theLabel</label>""")
+      clean(simpleInputWithArgs(Symbol("_label") -> "theLabel")) must contain(s"""<label class="control-label$labelExtraClasses" for="foo">theLabel</label>""")
     }
 
     "allow hide the label" in {
       val labelString = s"""<label class="control-label$labelExtraClasses sr-only" for="foo">theLabel</label>"""
-      clean(simpleInputWithArgs('_label -> "theLabel", '_hideLabel -> true)) must contain(labelString)
-      clean(simpleInputWithArgs('_hiddenLabel -> "theLabel")) must contain(labelString)
+      clean(simpleInputWithArgs(Symbol("_label") -> "theLabel", Symbol("_hideLabel") -> true)) must contain(labelString)
+      clean(simpleInputWithArgs(Symbol("_hiddenLabel") -> "theLabel")) must contain(labelString)
     }
 
     "allow render without label" in {
@@ -97,7 +97,7 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow showing constraints" in {
-      val test = simpleInputWithArgs('_showConstraints -> true)
+      val test = simpleInputWithArgs(Symbol("_showConstraints") -> true)
       test must contain("<span id=\"foo_info_0\" class=\"help-block\">")
       test must contain("<span id=\"foo_info_1\" class=\"help-block\">")
       test must contain("class=\"help-block\">" + msgsProv.messages("constraint.required") + "</span>")
@@ -105,14 +105,14 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow showing help info" in {
-      simpleInputWithArgs('_help -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_success -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_warning -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
-      simpleInputWithArgs('_error -> "test-help") must contain("<span id=\"foo_error_0\" class=\"help-block\">test-help</span>")
+      simpleInputWithArgs(Symbol("_help") -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
+      simpleInputWithArgs(Symbol("_success") -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
+      simpleInputWithArgs(Symbol("_warning") -> "test-help") must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
+      simpleInputWithArgs(Symbol("_error") -> "test-help") must contain("<span id=\"foo_error_0\" class=\"help-block\">test-help</span>")
     }
 
     "allow rendering erros and hide constraints when help info is present" in {
-      val test = simpleInputWithError('_showConstraints -> true, '_help -> "test-help")
+      val test = simpleInputWithError(Symbol("_showConstraints") -> true, Symbol("_help") -> "test-help")
       test must contain("<span id=\"foo_error_0\" class=\"help-block\">test-error-0</span>")
       test must contain("<span id=\"foo_error_1\" class=\"help-block\">test-error-1</span>")
       test must contain("<span id=\"foo_info_0\" class=\"help-block\">test-help</span>")
@@ -141,27 +141,27 @@ object FieldConstructorsSpec extends Specification {
         }
       }
 
-      testStatus("success", withIcon = false, '_success -> true)
-      testStatus("success", withIcon = false, '_success -> "test-help")
-      testStatus("warning", withIcon = false, '_warning -> true)
-      testStatus("warning", withIcon = false, '_warning -> "test-help")
-      testStatus("error", withIcon = false, '_error -> true)
-      testStatus("error", withIcon = false, '_error -> "test-help")
+      testStatus("success", withIcon = false, Symbol("_success") -> true)
+      testStatus("success", withIcon = false, Symbol("_success") -> "test-help")
+      testStatus("warning", withIcon = false, Symbol("_warning") -> true)
+      testStatus("warning", withIcon = false, Symbol("_warning") -> "test-help")
+      testStatus("error", withIcon = false, Symbol("_error") -> true)
+      testStatus("error", withIcon = false, Symbol("_error") -> "test-help")
 
       "with feedback icons" in {
-        testStatus("success", withIcon = true, '_showIconValid -> true)
-        testStatus("success", withIcon = true, '_success -> "test-help", '_showIconValid -> true)
-        testStatus("warning", withIcon = true, '_showIconWarning -> true)
-        testStatus("warning", withIcon = true, '_warning -> "test-help", '_showIconWarning -> true)
-        testStatus("error", withIcon = true, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("success", withIcon = true, Symbol("_showIconValid") -> true)
+        testStatus("success", withIcon = true, Symbol("_success") -> "test-help", Symbol("_showIconValid") -> true)
+        testStatus("warning", withIcon = true, Symbol("_showIconWarning") -> true)
+        testStatus("warning", withIcon = true, Symbol("_warning") -> "test-help", Symbol("_showIconWarning") -> true)
+        testStatus("error", withIcon = true, Symbol("_error") -> true, Symbol("_showIconOnError") -> true)
+        testStatus("error", withIcon = true, Symbol("_error") -> "test-help", Symbol("_showIconOnError") -> true)
       }
 
       "with automatic feedback icons" in {
-        testStatus("success", withIcon = true, '_success -> "test-help")(fcWithFeedbackIcons)
-        testStatus("warning", withIcon = true, '_warning -> "test-help")(fcWithFeedbackIcons)
-        testStatus("error", withIcon = true, '_error -> true)(fcWithFeedbackIcons)
-        testStatus("error", withIcon = true, '_error -> "test-help")(fcWithFeedbackIcons)
+        testStatus("success", withIcon = true, Symbol("_success") -> "test-help")(fcWithFeedbackIcons)
+        testStatus("warning", withIcon = true, Symbol("_warning") -> "test-help")(fcWithFeedbackIcons)
+        testStatus("error", withIcon = true, Symbol("_error") -> true)(fcWithFeedbackIcons)
+        testStatus("error", withIcon = true, Symbol("_error") -> "test-help")(fcWithFeedbackIcons)
       }
     }
 
@@ -173,7 +173,7 @@ object FieldConstructorsSpec extends Specification {
       test0 must not contain ("<span id=\"foo_info")
       test0 must not contain ("<span id=\"foo_error")
 
-      val test1 = simpleInputWithError('_showConstraints -> true, '_showIconOnError -> true)
+      val test1 = simpleInputWithError(Symbol("_showConstraints") -> true, Symbol("_showIconOnError") -> true)
       test1 must contain("aria-invalid=\"true\"")
       test1 must contain("aria-describedby=\"foo_status foo_info_0 foo_info_1 foo_error_0 foo_error_1\"")
       test1 must contain("<span id=\"foo_status\"")
@@ -182,7 +182,7 @@ object FieldConstructorsSpec extends Specification {
       test1 must contain("<span id=\"foo_error_0\"")
       test1 must contain("<span id=\"foo_error_1\"")
 
-      val test2 = simpleInputWithArgs('_help -> "test-help", '_showIconValid -> true)
+      val test2 = simpleInputWithArgs(Symbol("_help") -> "test-help", Symbol("_showIconValid") -> true)
       test2 must not contain ("aria-invalid")
       test2 must contain("aria-describedby=\"foo_status foo_info_0\"")
       test2 must contain("<span id=\"foo_status\"")
@@ -200,7 +200,7 @@ object FieldConstructorsSpec extends Specification {
     testFielConstructor(horizontalFieldConstructor, fcWithFeedbackIcons)
 
     "render columns for horizontal form" in {
-      val body = b3.text(Form(single("foo" -> Forms.text))("foo"), '_label -> "theLabel").body
+      val body = b3.text(Form(single("foo" -> Forms.text))("foo"), Symbol("_label") -> "theLabel").body
       body must contain(colLabel)
       body must contain(colInput)
     }

--- a/play27-bootstrap3/module/test/FormsSpec.scala
+++ b/play27-bootstrap3/module/test/FormsSpec.scala
@@ -65,7 +65,7 @@ object FormsSpec extends Specification {
     }
 
     "allow setting custom class" in {
-      fooFormBody('class -> "customClass")(vfc) must contain("class=\"form-vertical customClass\"")
+      fooFormBody(Symbol("class") -> "customClass")(vfc) must contain("class=\"form-vertical customClass\"")
     }
 
     "add form role as default" in {
@@ -73,7 +73,7 @@ object FormsSpec extends Specification {
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = fooFormBody('extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test")(vfc)
+      val body = fooFormBody(Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test")(vfc)
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")

--- a/play27-bootstrap3/module/test/HelpersSpec.scala
+++ b/play27-bootstrap3/module/test/HelpersSpec.scala
@@ -59,7 +59,7 @@ object HelpersSpec extends Specification {
   "@inputType" should {
 
     "allow setting a custom id" in {
-      val body = b3.inputType("text", fooField, 'id -> "someid").body
+      val body = b3.inputType("text", fooField, Symbol("id") -> "someid").body
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
       // Make sure it doesn't have it twice
@@ -79,11 +79,11 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b3.inputType("text", fooField, 'class -> "extra_class").body must contain("class=\"form-control extra_class\"")
+      b3.inputType("text", fooField, Symbol("class") -> "extra_class").body must contain("class=\"form-control extra_class\"")
     }
 
     "allow setting a default value" in {
-      val body = b3.inputType("text", fooField, 'value -> "defaultvalue").body
+      val body = b3.inputType("text", fooField, Symbol("value") -> "defaultvalue").body
       val valueAttr = "value=\"defaultvalue\""
       body must contain(valueAttr)
       // Make sure it doesn't contain it twice
@@ -91,7 +91,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow being filled with a value" in {
-      val body = b3.inputType("text", fooFieldFilled("filledvalue"), 'value -> "defaultvalue").body
+      val body = b3.inputType("text", fooFieldFilled("filledvalue"), Symbol("value") -> "defaultvalue").body
       val valueAttr = "value=\"filledvalue\""
       body must contain(valueAttr)
       // Make sure it doesn't contain it twice
@@ -101,7 +101,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = b3.inputType("text", fooField, 'extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test").body
+      val body = b3.inputType("text", fooField, Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test").body
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")
@@ -109,7 +109,7 @@ object HelpersSpec extends Specification {
     }
   }
 
-  val sampleArgs = Seq[(Symbol, Any)]('id -> "someid", 'foo -> "fooValue")
+  val sampleArgs = Seq[(Symbol, Any)](Symbol("id") -> "someid", Symbol("foo") -> "fooValue")
   def sampleInputTypeBody(theType: String) = b3.inputType(theType, fooField, sampleArgs: _*).body.trim
 
   "@text" should {
@@ -127,14 +127,14 @@ object HelpersSpec extends Specification {
   }
   "@file" should {
     "be equivalent to inputType with file type" in {
-      b3.file(fooField, (('class -> "form-control") +: sampleArgs): _*).body.trim must be equalTo sampleInputTypeBody("file")
+      b3.file(fooField, ((Symbol("class") -> "form-control") +: sampleArgs): _*).body.trim must be equalTo sampleInputTypeBody("file")
     }
   }
 
   "@textarea" should {
 
     "allow setting a custom id" in {
-      val body = b3.textarea(fooField, 'id -> "someid").body
+      val body = b3.textarea(fooField, Symbol("id") -> "someid").body
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
       // Make sure it doesn't have it twice
@@ -146,11 +146,11 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b3.textarea(fooField, 'class -> "extra_class").body must contain("class=\"form-control extra_class\"")
+      b3.textarea(fooField, Symbol("class") -> "extra_class").body must contain("class=\"form-control extra_class\"")
     }
 
     "allow setting a default value" in {
-      val body = b3.textarea(fooField, 'value -> "defaultvalue").body
+      val body = b3.textarea(fooField, Symbol("value") -> "defaultvalue").body
       body must contain(">defaultvalue</textarea>")
       body must not contain ("value=\"defaultvalue\"")
     }
@@ -163,7 +163,7 @@ object HelpersSpec extends Specification {
     def stringFieldFilled(v: String) = Form(single("foo" -> Forms.text)).fill(v)("foo")
 
     "allow setting a custom id" in {
-      val body = b3.checkbox(boolField, 'id -> "someid").body
+      val body = b3.checkbox(boolField, Symbol("id") -> "someid").body
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
       // Make sure it doesn't have it twice
@@ -177,19 +177,19 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting a default custom value" in {
-      val body = b3.checkbox(boolField, 'value -> "bar").body
+      val body = b3.checkbox(boolField, Symbol("value") -> "bar").body
       body must not contain ("checked")
       body must contain("value=\"bar\"")
     }
 
     "allow setting a default value for checked attribute" in {
-      val body = b3.checkbox(boolField, '_default -> true).body
+      val body = b3.checkbox(boolField, Symbol("_default") -> true).body
       body must contain("checked")
       body must contain("value=\"true\"")
     }
 
     "allow setting a default value for checked attribute with a custom value" in {
-      val body = b3.checkbox(boolField, 'value -> "bar", '_default -> true).body
+      val body = b3.checkbox(boolField, Symbol("value") -> "bar", Symbol("_default") -> true).body
       body must contain("checked")
       body must contain("value=\"bar\"")
     }
@@ -201,44 +201,44 @@ object HelpersSpec extends Specification {
     }
 
     "allow being filled with a custom value" in {
-      val body = b3.checkbox(stringFieldFilled("bar"), 'value -> "bar").body
+      val body = b3.checkbox(stringFieldFilled("bar"), Symbol("value") -> "bar").body
       body must contain("checked")
       body must contain("value=\"bar\"")
     }
 
     "ignore default checked value if it is filled" in {
-      val body1 = b3.checkbox(boolFieldFilled(false), '_default -> true).body
+      val body1 = b3.checkbox(boolFieldFilled(false), Symbol("_default") -> true).body
       body1 must not contain ("checked")
       body1 must contain("value=\"true\"")
-      val body2 = b3.checkbox(stringFieldFilled(""), 'value -> "bar", '_default -> true).body
+      val body2 = b3.checkbox(stringFieldFilled(""), Symbol("value") -> "bar", Symbol("_default") -> true).body
       body2 must not contain ("checked")
       body2 must contain("value=\"bar\"")
     }
 
     "allow setting a forced value for checked attribute (always true)" in {
-      val body = b3.checkbox(boolField, 'checked -> true).body
+      val body = b3.checkbox(boolField, Symbol("checked") -> true).body
       body must contain("checked")
       body must contain("value=\"true\"")
     }
     "allow setting a forced value for checked attribute (always false)" in {
-      val body = b3.checkbox(boolField, 'checked -> false).body
+      val body = b3.checkbox(boolField, Symbol("checked") -> false).body
       body must not contain ("checked")
       body must contain("value=\"true\"")
     }
 
     "add support to readonly attribute" in {
-      val bodyWithoutReadonly = b3.checkbox(boolField, 'value -> true).body
+      val bodyWithoutReadonly = b3.checkbox(boolField, Symbol("value") -> true).body
       bodyWithoutReadonly must contain("<div class=\"checkbox")
       bodyWithoutReadonly must not contain ("checkbox-group")
       bodyWithoutReadonly must not contain ("disabled")
       bodyWithoutReadonly must not contain ("<input type=\"hidden\"")
 
-      val bodyReadonlyFalse = b3.checkbox(boolField, 'readonly -> false, 'value -> true).body
+      val bodyReadonlyFalse = b3.checkbox(boolField, Symbol("readonly") -> false, Symbol("value") -> true).body
       bodyReadonlyFalse must contain("<div class=\"checkbox checkbox-group")
       bodyReadonlyFalse must not contain ("disabled=\"true\"")
       bodyReadonlyFalse must contain("<input type=\"hidden\" name=\"foo\" value=\"true\" disabled/>")
 
-      val bodyReadonlyTrue = b3.checkbox(boolField, 'readonly -> true, 'value -> true).body
+      val bodyReadonlyTrue = b3.checkbox(boolField, Symbol("readonly") -> true, Symbol("value") -> true).body
       bodyReadonlyTrue must contain("<div class=\"checkbox checkbox-group disabled\">")
       bodyReadonlyTrue must contain("disabled=\"true\"")
       bodyReadonlyTrue must contain("<input type=\"hidden\" name=\"foo\" value=\"true\"/>")
@@ -250,7 +250,7 @@ object HelpersSpec extends Specification {
     val fruits = Seq("A" -> "Apples", "P" -> "Pears", "B" -> "Bananas")
 
     "allow setting a custom id" in {
-      val body = b3.radio(fooField, fruits, 'id -> "someid").body
+      val body = b3.radio(fooField, fruits, Symbol("id") -> "someid").body
       body must contain("id=\"someid_A\"")
       body must contain("id=\"someid_P\"")
       body must contain("id=\"someid_B\"")
@@ -261,7 +261,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting a default value" in {
-      val body = b3.radio(fooField, fruits, 'value -> "B").body
+      val body = b3.radio(fooField, fruits, Symbol("value") -> "B").body
       val checkedAttr = "checked"
       body must contain(checkedAttr)
       // Make sure it doesn't have it twice
@@ -281,23 +281,23 @@ object HelpersSpec extends Specification {
     }
 
     "allow be inline" in {
-      b3.radio(fooField, fruits, '_inline -> true).body must contain("radio-inline")
+      b3.radio(fooField, fruits, Symbol("_inline") -> true).body must contain("radio-inline")
     }
 
     "add support to readonly attribute" in {
-      val bodyWithoutReadonly = b3.radio(fooField, fruits, 'value -> "B").body
+      val bodyWithoutReadonly = b3.radio(fooField, fruits, Symbol("value") -> "B").body
       bodyWithoutReadonly must not contain ("radio-group")
       bodyWithoutReadonly must not contain ("disabled")
       bodyWithoutReadonly must not contain ("<input type=\"hidden\"")
 
-      val bodyReadonlyFalse = b3.radio(fooField, fruits, 'readonly -> false, 'value -> "B").body
+      val bodyReadonlyFalse = b3.radio(fooField, fruits, Symbol("readonly") -> false, Symbol("value") -> "B").body
       bodyReadonlyFalse must contain("<div class=\"radio-group\">")
       bodyReadonlyFalse must not contain ("disabled=\"true\"")
       bodyReadonlyFalse must contain("<div class=\"radio")
       bodyReadonlyFalse must not contain ("<div class=\"radio disabled\"")
       bodyReadonlyFalse must contain("<input type=\"hidden\" name=\"foo\" value=\"B\" disabled/>")
 
-      val bodyReadonlyTrue = b3.radio(fooField, fruits, 'readonly -> true, 'value -> "B").body
+      val bodyReadonlyTrue = b3.radio(fooField, fruits, Symbol("readonly") -> true, Symbol("value") -> "B").body
       bodyReadonlyTrue must contain("<div class=\"radio-group\">")
       bodyReadonlyTrue must contain("disabled=\"true\"")
       bodyReadonlyTrue must contain("<div class=\"radio disabled\"")
@@ -310,7 +310,7 @@ object HelpersSpec extends Specification {
     val fruits = Seq("A" -> "Apples", "P" -> "Pears", "B" -> "Bananas")
 
     "allow setting a custom id" in {
-      val body = b3.select(fooField, fruits, 'id -> "someid").body
+      val body = b3.select(fooField, fruits, Symbol("id") -> "someid").body
       body must contain("id=\"someid\"")
     }
 
@@ -319,7 +319,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b3.select(fooField, fruits, 'class -> "extra_class").body must contain("class=\"form-control extra_class\"")
+      b3.select(fooField, fruits, Symbol("class") -> "extra_class").body must contain("class=\"form-control extra_class\"")
     }
 
     "be unselected by default" in {
@@ -327,7 +327,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting a default value" in {
-      val body = b3.select(fooField, fruits, 'value -> "B").body
+      val body = b3.select(fooField, fruits, Symbol("value") -> "B").body
       val selectedAttr = "selected"
       body must contain(selectedAttr)
       // Make sure it doesn't have it twice
@@ -343,24 +343,24 @@ object HelpersSpec extends Specification {
     }
 
     "add support to readonly attribute" in {
-      val bodyWithoutReadonly = b3.select(fooField, fruits, 'value -> "B").body
+      val bodyWithoutReadonly = b3.select(fooField, fruits, Symbol("value") -> "B").body
       bodyWithoutReadonly must not contain ("<div class=\"select-group\">")
       bodyWithoutReadonly must not contain ("disabled")
       bodyWithoutReadonly must not contain ("<input type=\"hidden\"")
 
-      val bodyReadonlyFalse = b3.select(fooField, fruits, 'readonly -> false, 'value -> "B").body
+      val bodyReadonlyFalse = b3.select(fooField, fruits, Symbol("readonly") -> false, Symbol("value") -> "B").body
       bodyReadonlyFalse must contain("<div class=\"select-group\">")
       bodyReadonlyFalse must not contain ("disabled=\"true\"")
       bodyReadonlyFalse must contain("<input type=\"hidden\" name=\"foo\" value=\"B\" disabled/>")
 
-      val bodyReadonlyTrue = b3.select(fooField, fruits, 'readonly -> true, 'value -> "B").body
+      val bodyReadonlyTrue = b3.select(fooField, fruits, Symbol("readonly") -> true, Symbol("value") -> "B").body
       bodyReadonlyTrue must contain("<div class=\"select-group\">")
       bodyReadonlyTrue must contain("disabled=\"true\"")
       bodyReadonlyTrue must contain("<input type=\"hidden\" name=\"foo\" value=\"B\"/>")
     }
 
     "allow multiple" in {
-      val body = b3.select(fooField, fruits, 'multiple -> true, 'value -> "P,B").body
+      val body = b3.select(fooField, fruits, Symbol("multiple") -> true, Symbol("value") -> "P,B").body
       body must contain("multiple=\"true\"")
       val selectedAttr = "selected"
       body must contain(selectedAttr)
@@ -373,15 +373,15 @@ object HelpersSpec extends Specification {
 
   "@hidden" should {
     "be rendered correctly" in {
-      val body = clean(b3.hidden("testName", "testValue", 'foo -> "bar").body)
+      val body = clean(b3.hidden("testName", "testValue", Symbol("foo") -> "bar").body)
       body must be equalTo """<input type="hidden" name="testName" value="testValue" foo="bar">"""
     }
     "with Field object" in {
-      val body = clean(b3.hidden(fooField, 'value -> "testValue", 'foo -> "bar").body)
+      val body = clean(b3.hidden(fooField, Symbol("value") -> "testValue", Symbol("foo") -> "bar").body)
       body must be equalTo """<input type="hidden" name="foo" value="testValue" foo="bar">"""
     }
     "with filled Field object" in {
-      val body = clean(b3.hidden(fooFieldFilled("filledValue"), 'value -> "testValue", 'foo -> "bar").body)
+      val body = clean(b3.hidden(fooFieldFilled("filledValue"), Symbol("value") -> "testValue", Symbol("foo") -> "bar").body)
       body must be equalTo """<input type="hidden" name="foo" value="filledValue" foo="bar">"""
     }
   }
@@ -464,7 +464,7 @@ object HelpersSpec extends Specification {
       clean(b3.freeFormGroup(args)(innerArgs => Html("<content>"))(fc, msgsProv).body)
 
     "vertical: show label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(vfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId", Symbol("_label") -> "theLabel")(vfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<label class="control-label">theLabel</label>
 	  	<content>
@@ -472,14 +472,14 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "vertical: without label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId")(vfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId")(vfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<content>
 	  </div>
 	  """)
     }
     "horizontal: show label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(hfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId", Symbol("_label") -> "theLabel")(hfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<label class="control-label col-md-2">theLabel</label>
 	  	<div class="col-md-10">
@@ -489,7 +489,7 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "horizontal: without label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId")(hfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId")(hfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<div class="col-md-10 col-md-offset-2">
 	  	  <content>
@@ -498,7 +498,7 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "inline: show label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(ifc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId", Symbol("_label") -> "theLabel")(ifc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<label class="control-label">theLabel</label>
 		<content>
@@ -506,7 +506,7 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "inline: without label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId")(ifc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId")(ifc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 		<content>
 	  </div>
@@ -514,7 +514,7 @@ object HelpersSpec extends Specification {
     }
 
     "get the inner arguments for the content" in {
-      val body = b3.freeFormGroup(Seq('_class -> "theClass", '_underscored -> "underscored", 'foo -> "foo"))(innerArgsMap => Html(innerArgsMap.toSeq.map(a => s"""${a._1.name}="${a._2.toString}"""").mkString("<content ", " ", ">")))(vfc, msgsProv).body
+      val body = b3.freeFormGroup(Seq(Symbol("_class") -> "theClass", Symbol("_underscored") -> "underscored", Symbol("foo") -> "foo"))(innerArgsMap => Html(innerArgsMap.toSeq.map(a => s"""${a._1.name}="${a._2.toString}"""").mkString("<content ", " ", ">")))(vfc, msgsProv).body
       body must not contain "_class=\"theClass\""
       body must not contain "_underscored=\"underscored\""
       body must contain("foo=\"foo\"")
@@ -523,7 +523,7 @@ object HelpersSpec extends Specification {
 
   "@free" should {
     "be rendered correctly" in {
-      clean(b3.free('foo -> "fooValue")(Html("<content>"))(vfc, msgsProv).body) must be equalTo clean(b3.freeFormGroup(Seq('foo -> "fooValue"))(_ => Html("<content>"))(vfc, msgsProv).body)
+      clean(b3.free(Symbol("foo") -> "fooValue")(Html("<content>"))(vfc, msgsProv).body) must be equalTo clean(b3.freeFormGroup(Seq(Symbol("foo") -> "fooValue"))(_ => Html("<content>"))(vfc, msgsProv).body)
     }
   }
 
@@ -534,11 +534,11 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b3.static("theLabel", 'class -> "extra_class")(Html("theText"))(vfc, msgsProv).body must contain("<p class=\"form-control-static extra_class\">theText</p>")
+      b3.static("theLabel", Symbol("class") -> "extra_class")(Html("theText"))(vfc, msgsProv).body must contain("<p class=\"form-control-static extra_class\">theText</p>")
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = b3.static("theLabel", 'extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test")(Html("theText"))(vfc, msgsProv).body
+      val body = b3.static("theLabel", Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test")(Html("theText"))(vfc, msgsProv).body
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")
@@ -564,7 +564,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = buttonTypeBody('extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test")
+      val body = buttonTypeBody(Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test")
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")
@@ -572,7 +572,7 @@ object HelpersSpec extends Specification {
     }
 
     "be rendered correctly" in {
-      val body = buttonTypeBody('id -> "someid", 'class -> "btn btn-default")
+      val body = buttonTypeBody(Symbol("id") -> "someid", Symbol("class") -> "btn btn-default")
       body must contain("<button type=\"" + sampleType + "\" id=\"someid\" class=\"btn btn-default\">" + sampleContent + "</button>")
     }
   }
@@ -598,16 +598,16 @@ object HelpersSpec extends Specification {
   "@inputWrapped" should {
 
     "be equivalent to inputType for an empty wrapper" in {
-      val bodyInputType = clean(b3.inputType("text", fooField, 'id -> "someid").body)
-      val body = clean(b3.inputWrapped("text", fooField, 'id -> "someid")(x => x).body)
+      val bodyInputType = clean(b3.inputType("text", fooField, Symbol("id") -> "someid").body)
+      val body = clean(b3.inputWrapped("text", fooField, Symbol("id") -> "someid")(x => x).body)
       body must be equalTo bodyInputType
     }
 
     "wrap the input" in {
-      val bodyInputType = clean(b3.inputType("text", fooField, 'id -> "someid").body)
+      val bodyInputType = clean(b3.inputType("text", fooField, Symbol("id") -> "someid").body)
       val (wrapperPre, wrapperPost) = ("<wrapper>", "</wrapper>")
       def wrap(input: Html) = HtmlFormat.fill(scala.collection.immutable.Seq(Html(wrapperPre), input, Html(wrapperPost)))
-      val body = clean(b3.inputWrapped("text", fooField, 'id -> "someid")(input => wrap(input)).body)
+      val body = clean(b3.inputWrapped("text", fooField, Symbol("id") -> "someid")(input => wrap(input)).body)
 
       val (indexOfWrapperPre, indexOfWrapperPost) = (body.indexOf(wrapperPre), body.indexOf(wrapperPost))
 
@@ -631,7 +631,7 @@ object HelpersSpec extends Specification {
     def fooMultifieldWithFielsArgs(fieldsArgs: (Symbol, Any)*) = multifield(fooForm, fieldsArgs = fieldsArgs)(vfc, msgsProv)
 
     "have the basic structure" in {
-      val body = fooMultifield('_label -> "theLabel")
+      val body = fooMultifield(Symbol("_label") -> "theLabel")
       body must contain("class=\"form-group")
       body must not contain ("has-error")
       body must contain("<label class=\"control-label\">theLabel</label>")
@@ -640,22 +640,22 @@ object HelpersSpec extends Specification {
     }
 
     "behave as a horizontal field constructor" in {
-      val body = multifield(fooForm, Seq('_label -> "theLabel"))(hfc, msgsProv)
+      val body = multifield(fooForm, Seq(Symbol("_label") -> "theLabel"))(hfc, msgsProv)
       body must contain("<label class=\"control-label " + colLabel + "\">theLabel</label>")
       body must contain("<div class=\"" + colInput + "\">")
     }
 
     "allow setting a custom id" in {
-      fooMultifield('_id -> "customid") must contain("id=\"customid\"")
+      fooMultifield(Symbol("_id") -> "customid") must contain("id=\"customid\"")
     }
 
     "allow setting extra classes form-group" in {
-      fooMultifield('_class -> "extra_class another_class") must contain("class=\"form-group extra_class another_class")
+      fooMultifield(Symbol("_class") -> "extra_class another_class") must contain("class=\"form-group extra_class another_class")
     }
 
     "show label" in {
-      multifield(fooForm, Seq('_label -> "fooLabel"))(vfc, msgsProv) must contain("<label class=\"control-label\">fooLabel</label>")
-      multifield(fooForm, Seq('_label -> "fooLabel"))(hfc, msgsProv) must contain("<label class=\"control-label " + colLabel + "\">fooLabel</label>")
+      multifield(fooForm, Seq(Symbol("_label") -> "fooLabel"))(vfc, msgsProv) must contain("<label class=\"control-label\">fooLabel</label>")
+      multifield(fooForm, Seq(Symbol("_label") -> "fooLabel"))(hfc, msgsProv) must contain("<label class=\"control-label " + colLabel + "\">fooLabel</label>")
     }
 
     "without label" in {
@@ -670,17 +670,17 @@ object HelpersSpec extends Specification {
     }
 
     "allow showing constraints" in {
-      multifield(fooForm, fieldsArgs = Seq('_showConstraints -> true))(vfc, msgsProv) must contain("<span class=\"help-block\">" + msgsProv.messages("constraint.required") + "</span>")
+      multifield(fooForm, fieldsArgs = Seq(Symbol("_showConstraints") -> true))(vfc, msgsProv) must contain("<span class=\"help-block\">" + msgsProv.messages("constraint.required") + "</span>")
     }
 
     "allow showing help info" in {
-      fooMultifield('_help -> "test-help") must contain("""<span class="help-block">test-help</span>""")
-      fooMultifield('_success -> "test-help") must contain("""<span class="help-block">test-help</span>""")
-      fooMultifieldWithFielsArgs('_success -> "test-help") must contain("""<span class="help-block">test-help</span>""")
-      fooMultifield('_warning -> "test-help") must contain("""<span class="help-block">test-help</span>""")
-      fooMultifieldWithFielsArgs('_warning -> "test-help") must contain("""<span class="help-block">test-help</span>""")
-      fooMultifield('_error -> "test-help") must contain("""<span class="help-block">test-help</span>""")
-      fooMultifieldWithFielsArgs('_error -> "test-help") must contain("""<span class="help-block">test-help</span>""")
+      fooMultifield(Symbol("_help") -> "test-help") must contain("""<span class="help-block">test-help</span>""")
+      fooMultifield(Symbol("_success") -> "test-help") must contain("""<span class="help-block">test-help</span>""")
+      fooMultifieldWithFielsArgs(Symbol("_success") -> "test-help") must contain("""<span class="help-block">test-help</span>""")
+      fooMultifield(Symbol("_warning") -> "test-help") must contain("""<span class="help-block">test-help</span>""")
+      fooMultifieldWithFielsArgs(Symbol("_warning") -> "test-help") must contain("""<span class="help-block">test-help</span>""")
+      fooMultifield(Symbol("_error") -> "test-help") must contain("""<span class="help-block">test-help</span>""")
+      fooMultifieldWithFielsArgs(Symbol("_error") -> "test-help") must contain("""<span class="help-block">test-help</span>""")
     }
 
     "render validation states" in {
@@ -697,9 +697,9 @@ object HelpersSpec extends Specification {
       ))
       def testStatus(status: String, withIcon: Boolean, withFieldsArgs: Boolean, args: (Symbol, Any)*) = {
         val test = if (withFieldsArgs)
-          clean(b3.multifield(fooForm("foo"))(globalArgs = if (withIcon) Seq('_hasFeedback -> true) else Seq(), fieldsArgs = args)(cfc => b3.text(fooForm("foo"), args: _*))(vfc, msgsProv).body)
+          clean(b3.multifield(fooForm("foo"))(globalArgs = if (withIcon) Seq(Symbol("_hasFeedback") -> true) else Seq(), fieldsArgs = args)(cfc => b3.text(fooForm("foo"), args: _*))(vfc, msgsProv).body)
         else
-          clean(b3.multifield(fooForm("foo"))(globalArgs = if (withIcon) (('_hasFeedback -> true) +: args) else args, fieldsArgs = Seq())(cfc => b3.text(fooForm("foo"), args: _*))(vfc, msgsProv).body)
+          clean(b3.multifield(fooForm("foo"))(globalArgs = if (withIcon) ((Symbol("_hasFeedback") -> true) +: args) else args, fieldsArgs = Seq())(cfc => b3.text(fooForm("foo"), args: _*))(vfc, msgsProv).body)
         test must withStatus(status, withIcon)
         if (withIcon) {
           test must withFeedbackIcon(status)
@@ -708,32 +708,32 @@ object HelpersSpec extends Specification {
         }
       }
 
-      testStatus("success", withIcon = false, withFieldsArgs = false, '_success -> true)
-      testStatus("success", withIcon = false, withFieldsArgs = true, '_success -> true)
-      testStatus("success", withIcon = false, withFieldsArgs = false, '_success -> "test-help")
-      testStatus("success", withIcon = false, withFieldsArgs = true, '_success -> "test-help")
-      testStatus("warning", withIcon = false, withFieldsArgs = false, '_warning -> true)
-      testStatus("warning", withIcon = false, withFieldsArgs = true, '_warning -> true)
-      testStatus("warning", withIcon = false, withFieldsArgs = false, '_warning -> "test-help")
-      testStatus("warning", withIcon = false, withFieldsArgs = true, '_warning -> "test-help")
-      testStatus("error", withIcon = false, withFieldsArgs = false, '_error -> true)
-      testStatus("error", withIcon = false, withFieldsArgs = true, '_error -> true)
-      testStatus("error", withIcon = false, withFieldsArgs = false, '_error -> "test-help")
-      testStatus("error", withIcon = false, withFieldsArgs = true, '_error -> "test-help")
+      testStatus("success", withIcon = false, withFieldsArgs = false, Symbol("_success") -> true)
+      testStatus("success", withIcon = false, withFieldsArgs = true, Symbol("_success") -> true)
+      testStatus("success", withIcon = false, withFieldsArgs = false, Symbol("_success") -> "test-help")
+      testStatus("success", withIcon = false, withFieldsArgs = true, Symbol("_success") -> "test-help")
+      testStatus("warning", withIcon = false, withFieldsArgs = false, Symbol("_warning") -> true)
+      testStatus("warning", withIcon = false, withFieldsArgs = true, Symbol("_warning") -> true)
+      testStatus("warning", withIcon = false, withFieldsArgs = false, Symbol("_warning") -> "test-help")
+      testStatus("warning", withIcon = false, withFieldsArgs = true, Symbol("_warning") -> "test-help")
+      testStatus("error", withIcon = false, withFieldsArgs = false, Symbol("_error") -> true)
+      testStatus("error", withIcon = false, withFieldsArgs = true, Symbol("_error") -> true)
+      testStatus("error", withIcon = false, withFieldsArgs = false, Symbol("_error") -> "test-help")
+      testStatus("error", withIcon = false, withFieldsArgs = true, Symbol("_error") -> "test-help")
 
       "with feedback icons" in {
-        testStatus("success", withIcon = true, withFieldsArgs = false, '_showIconValid -> true)
-        testStatus("success", withIcon = true, withFieldsArgs = true, '_showIconValid -> true)
-        testStatus("success", withIcon = true, withFieldsArgs = false, '_success -> "test-help", '_showIconValid -> true)
-        testStatus("success", withIcon = true, withFieldsArgs = true, '_success -> "test-help", '_showIconValid -> true)
-        testStatus("warning", withIcon = true, withFieldsArgs = false, '_showIconWarning -> true)
-        testStatus("warning", withIcon = true, withFieldsArgs = true, '_showIconWarning -> true)
-        testStatus("warning", withIcon = true, withFieldsArgs = false, '_warning -> "test-help", '_showIconWarning -> true)
-        testStatus("warning", withIcon = true, withFieldsArgs = true, '_warning -> "test-help", '_showIconWarning -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = false, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = true, '_error -> true, '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = false, '_error -> "test-help", '_showIconOnError -> true)
-        testStatus("error", withIcon = true, withFieldsArgs = true, '_error -> "test-help", '_showIconOnError -> true)
+        testStatus("success", withIcon = true, withFieldsArgs = false, Symbol("_showIconValid") -> true)
+        testStatus("success", withIcon = true, withFieldsArgs = true, Symbol("_showIconValid") -> true)
+        testStatus("success", withIcon = true, withFieldsArgs = false, Symbol("_success") -> "test-help", Symbol("_showIconValid") -> true)
+        testStatus("success", withIcon = true, withFieldsArgs = true, Symbol("_success") -> "test-help", Symbol("_showIconValid") -> true)
+        testStatus("warning", withIcon = true, withFieldsArgs = false, Symbol("_showIconWarning") -> true)
+        testStatus("warning", withIcon = true, withFieldsArgs = true, Symbol("_showIconWarning") -> true)
+        testStatus("warning", withIcon = true, withFieldsArgs = false, Symbol("_warning") -> "test-help", Symbol("_showIconWarning") -> true)
+        testStatus("warning", withIcon = true, withFieldsArgs = true, Symbol("_warning") -> "test-help", Symbol("_showIconWarning") -> true)
+        testStatus("error", withIcon = true, withFieldsArgs = false, Symbol("_error") -> true, Symbol("_showIconOnError") -> true)
+        testStatus("error", withIcon = true, withFieldsArgs = true, Symbol("_error") -> true, Symbol("_showIconOnError") -> true)
+        testStatus("error", withIcon = true, withFieldsArgs = false, Symbol("_error") -> "test-help", Symbol("_showIconOnError") -> true)
+        testStatus("error", withIcon = true, withFieldsArgs = true, Symbol("_error") -> "test-help", Symbol("_showIconOnError") -> true)
       }
     }
 

--- a/play27-bootstrap3/sample/app/views/b3/my/email.scala.html
+++ b/play27-bootstrap3/sample/app/views/b3/my/email.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, args: (Symbol,Any)*)(implicit handler: b3.B3FieldConstructor, msgsProv: MessagesProvider)
-@b3.inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(args, 'class -> "form-control")) { fieldInfo =>
+@b3.inputFormGroup(field, withFeedback = false, withLabelFor = true, bs.Args.withDefault(args, Symbol("class") -> "form-control")) { fieldInfo =>
 	<div class="input-group">
 		<span class="input-group-addon">@@</span>
 		<input type="email" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(fieldInfo.innerArgsMap)>

--- a/play27-bootstrap3/sample/app/views/b3/my/vertical/bsFieldConstructor.scala.html
+++ b/play27-bootstrap3/sample/app/views/b3/my/vertical/bsFieldConstructor.scala.html
@@ -2,7 +2,7 @@
 @alertStatus = @{
 	if (fieldInfo.hasErrors)
 		"alert-danger"
-	else if (bs.ArgsMap.isTrue(fieldInfo.argsMap, '_success))
+	else if (bs.ArgsMap.isTrue(fieldInfo.argsMap, Symbol("_success")))
 		"alert-success"
 	else
 		"alert-info"

--- a/play27-bootstrap3/sample/app/views/b3/my/vertical/bsFieldConstructor.scala.html
+++ b/play27-bootstrap3/sample/app/views/b3/my/vertical/bsFieldConstructor.scala.html
@@ -7,7 +7,7 @@
 	else
 		"alert-info"
 }
-<div class="my-form-group form-group @fieldInfo.argsMap.get('_class) @fieldInfo.statusWithFeedback" id="@fieldInfo.idFormField">
+<div class="my-form-group form-group @fieldInfo.argsMap.get(Symbol("_class")) @fieldInfo.statusWithFeedback" id="@fieldInfo.idFormField">
 	<div class="field-container">
 		@fieldInfo.labelOpt.map { label =>
 			<label class="control-label @if(fieldInfo.hideLabel){sr-only}" @if(fieldInfo.withLabelFor){for="@fieldInfo.id"}>@bs.Args.msg(label)(msgsProv)</label>

--- a/play27-bootstrap3/sample/app/views/b3/my/vertical/bsFormGroup.scala.html
+++ b/play27-bootstrap3/sample/app/views/b3/my/vertical/bsFormGroup.scala.html
@@ -1,14 +1,14 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit msgsProv: MessagesProvider)
-<div class="my-form-group form-group @argsMap.get('_class)" id="@argsMap.get('_id)">
+<div class="my-form-group form-group @argsMap.get(Symbol("_class"))" id="@argsMap.get(Symbol("_id"))">
 	<div class="field-container">
-		@argsMap.get('_label).map { label =>
+		@argsMap.get(Symbol("_label")).map { label =>
 			<label class="control-label">@bs.Args.msg(label)(msgsProv)</label>
 		}
 		@contentHtml
 	</div>
 	<div class="alert alert-info" role="alert">
 		<ul>
-			@argsMap.get('_help).map { help =>
+			@argsMap.get(Symbol("_help")).map { help =>
 				<li><span class="help-info"><span class="glyphicon glyphicon-warning-sign"> @bs.Args.msg(help)(msgsProv)</span></li>
 			}
 		</ul>

--- a/play27-bootstrap3/sample/app/views/docs.scala.html
+++ b/play27-bootstrap3/sample/app/views/docs.scala.html
@@ -38,9 +38,9 @@
 
 			<h3 id="arguments">Arguments (<code>args</code>)</h3>
 			@bsExampleWithCode {
-				@b3.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			}{
-				@@b3.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@@b3.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			}
 
 			<h4 id="arguments-special">Special arguments (the underscored ones)</h4>
@@ -48,16 +48,16 @@
 			<h4 id="arguments-validation">Validation arguments</h4>
 			@bsExampleWithCode {
         <div class="example-html5-validation">
-          @b3.text( validationForm("username"), '_label -> "Username", '_help -> "A username between 1 and 20 characters" )
-          @b3.email( validationForm("email"), '_label -> "Email" )
-          @b3.number( validationForm("age"), '_label -> "Age", '_help -> "From 18 to 99 years old" )
-          @b3.text( validationForm("color"), '_label -> "Hexadecimal color", '_help -> "Format is #CCC or #CCCCCC" )
+          @b3.text( validationForm("username"), Symbol("_label") -> "Username", Symbol("_help") -> "A username between 1 and 20 characters" )
+          @b3.email( validationForm("email"), Symbol("_label") -> "Email" )
+          @b3.number( validationForm("age"), Symbol("_label") -> "Age", Symbol("_help") -> "From 18 to 99 years old" )
+          @b3.text( validationForm("color"), Symbol("_label") -> "Hexadecimal color", Symbol("_help") -> "Format is #CCC or #CCCCCC" )
         </div>
 			}{
-				@@b3.text( validationForm("username"), '_label -> "Username", '_help -> "A username between 1 and 20 characters" )
-				@@b3.email( validationForm("email"), '_label -> "Email" )
-				@@b3.number( validationForm("age"), '_label -> "Age", '_help -> "From 18 to 99 years old" )
-				@@b3.text( validationForm("color"), '_label -> "Hexadecimal color", '_help -> "Format is #CCC or #CCCCCC" )
+				@@b3.text( validationForm("username"), Symbol("_label") -> "Username", Symbol("_help") -> "A username between 1 and 20 characters" )
+				@@b3.email( validationForm("email"), Symbol("_label") -> "Email" )
+				@@b3.number( validationForm("age"), Symbol("_label") -> "Age", Symbol("_help") -> "From 18 to 99 years old" )
+				@@b3.text( validationForm("color"), Symbol("_label") -> "Hexadecimal color", Symbol("_help") -> "Format is #CCC or #CCCCCC" )
 			}
 
 
@@ -79,38 +79,38 @@
 			<h4 id="helpers-disabled-readonly">About <code>disabled</code> and <code>readonly</code> attributes</h4>
 			<h4 id="helpers-validation-states">Validation states & feedback icons</h4>
 			@bsExampleWithCode {
-				@b3.text( fooForm("foo"), '_label -> "Success", '_success -> true, 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> true, Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			}{
-				@@b3.text( fooForm("foo"), '_label -> "Success", '_success -> true, 'placeholder -> "Success text..." )
-				@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> true, Symbol("placeholder") -> "Success text..." )
+				@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			}
 			@bsExampleWithCode {
-				@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			}{
-				@@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-				@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-				@@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+				@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+				@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			}
 
 
 
 			<h4 id="helper-inputtype"><code>b3.inputType</code> <span class="def">@@(inputType: String, field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
 			<p>
-				It renders a simple input with a specific type attribute and it adds <code>class="form-control"</code> by default, but you can add an extra class with <code>'class -> "extra_class"</code>.
+				It renders a simple input with a specific type attribute and it adds <code>class="form-control"</code> by default, but you can add an extra class with <code>Symbol("class") -> "extra_class"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.inputType( "text", fooForm("name"), 'class -> "extra_class", '_label -> "Name", 'placeholder -> "John Doe" )
-				@b3.inputType( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
-				@b3.inputType( "password", fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@b3.inputType( "text", fooForm("name"), Symbol("class") -> "extra_class", Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
+				@b3.inputType( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+				@b3.inputType( "password", fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}{
-				@@b3.inputType( "text", fooForm("name"), 'class -> "extra_class", '_label -> "Name", 'placeholder -> "John Doe" )
-				@@b3.inputType( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-				@@b3.inputType( "password", fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@@b3.inputType( "text", fooForm("name"), Symbol("class") -> "extra_class", Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
+				@@b3.inputType( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+				@@b3.inputType( "password", fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}
 
 
@@ -119,9 +119,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="text"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.text( fooForm("name"), '_label -> "Name", 'placeholder -> "John Doe" )
+				@b3.text( fooForm("name"), Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
 			}{
-				@@b3.text( fooForm("name"), '_label -> "Name", 'placeholder -> "John Doe" )
+				@@b3.text( fooForm("name"), Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
 			}
 
 
@@ -133,9 +133,9 @@
 				For security reasons, this helper doesn't display the possible value the field could have (for example when the form is reloaded after a validation failure).
 			</p>
 			@bsExampleWithCode {
-				@b3.password( fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@b3.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}{
-				@@b3.password( fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@@b3.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}
 
 
@@ -144,11 +144,11 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="file"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.file( fooForm("file"), '_label -> "File" )
-				@b3.file( fooForm("file"), '_label -> "File", 'class -> "form-control" )
+				@b3.file( fooForm("file"), Symbol("_label") -> "File" )
+				@b3.file( fooForm("file"), Symbol("_label") -> "File", Symbol("class") -> "form-control" )
 			}{
-				@@b3.file( fooForm("file"), '_label -> "File" )
-				@@b3.file( fooForm("file"), '_label -> "File", 'class -> "form-control" )
+				@@b3.file( fooForm("file"), Symbol("_label") -> "File" )
+				@@b3.file( fooForm("file"), Symbol("_label") -> "File", Symbol("class") -> "form-control" )
 			}
 
 
@@ -158,9 +158,9 @@
 				It renders a textarea and it adds <code>class="form-control"</code> by default.
 			</p>
 			@bsExampleWithCode {
-				@b3.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
+				@b3.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
 			}{
-				@@b3.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
+				@@b3.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
 			}
 
 
@@ -173,7 +173,7 @@
 				The special <code>'_text</code> argument lets you put a text after the checkbox.
 			</p>
       <p>
-        Regarding to the <code>checked</code> attribute, if you want to set it to <strong>true</strong> as default, use <code>'_default -> true</code>.
+        Regarding to the <code>checked</code> attribute, if you want to set it to <strong>true</strong> as default, use <code>Symbol("_default") -> true</code>.
         And if you need to force its value use directly the <code>'checked</code> argument.
       </p>
 			<p>
@@ -181,32 +181,32 @@
 				<code>&lt;input type="hidden"&gt;</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.checkbox( fooForm("foo"), '_text -> "Remember me" )
+				@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me" )
 			}{
-				@@b3.checkbox( fooForm("foo"), '_text -> "Remember me" )
+				@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me" )
 
 				// uses "bar" as value for the checkbox
-				@@b3.checkbox( fooForm("foo"), '_text -> "Remember me", 'value -> "bar" )
+				@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("value") -> "bar" )
 
 				// checked by default (if the form is filled, this value will be taken)
-				@@b3.checkbox( fooForm("foo"), '_text -> "Remember me", '_default -> true )
+				@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("_default") -> true )
 
 				// always checked (even if the form has been filled with a false)
-				@@b3.checkbox( fooForm("foo"), '_text -> "Remember me", 'checked -> true )
+				@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("checked") -> true )
 
 				// disabled -> it will NOT be sent within the POST request
-				@@b3.checkbox( fooForm("foo"), '_text -> "Remember me", 'disabled -> true )
+				@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("disabled") -> true )
 
 				// readonly -> it will be sent within the POST request
-				@@b3.checkbox( fooForm("foo"), '_text -> "Remember me", 'readonly -> true )
+				@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("readonly") -> true )
 			}
 			<p>
 				Note you can use any value for the <code>_text</code> argument.
 			</p>
 			@bsExampleWithCode {
-				@b3.checkbox( fooForm("foo"), '_text -> Html("""Do you want a beer? <i class="fa fa-beer"></i>""") )
+				@b3.checkbox( fooForm("foo"), Symbol("_text") -> Html("""Do you want a beer? <i class="fa fa-beer"></i>""") )
 			}{
-				@@b3.checkbox( fooForm("foo"), '_text -> Html("Do you want a beer? <i class=\"fa fa-beer\"></i>") )
+				@@b3.checkbox( fooForm("foo"), Symbol("_text") -> Html("Do you want a beer? <i class=\"fa fa-beer\"></i>") )
 			}
 
 
@@ -219,31 +219,31 @@
 				It has an additional special <code>_inline</code> argument to make it an inline radio (for vertical and horizontal forms).
 			</p>
 			@bsExampleWithCode {
-				@b3.radio( fooForm("foo_radio1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+				@b3.radio( fooForm("foo_radio1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 			}{
 				@@opts = @@{ Seq("M"->"Male","F"->"Female") }
 
-				@@b3.radio( fooForm("foo"), options = opts, '_label -> "Radio Group" )
+				@@b3.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group" )
 
 				// an inline radio within a vertical or horizontal form
-				@@b3.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", '_inline -> true )
+				@@b3.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("_inline") -> true )
 
 				// with value "F" by default (if the form is filled, this value will be taken)
-				@@b3.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", 'value -> "F" )
+				@@b3.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("value") -> "F" )
 
 				// disabled -> it will NOT be sent within the POST request
-				@@b3.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", 'disabled -> true )
+				@@b3.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("disabled") -> true )
 
 				// readonly -> it will be sent within the POST request
-				@@b3.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", 'readonly -> true )
+				@@b3.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("readonly") -> true )
 			}
 			<p>
 				Note you can use any value for the <code>options</code> argument.
 			</p>
 			@bsExampleWithCode {
-				@b3.radio( fooForm("foo_radio2"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), '_label -> "What do you prefer?" )
+				@b3.radio( fooForm("foo_radio2"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), Symbol("_label") -> "What do you prefer?" )
 			}{
-				@@b3.radio( fooForm("foo"), options = Seq("B" -> Html("Beer <i class=\"fa fa-beer\"></i>"), "C" -> Html("Coffee <i class=\"fa fa-coffee\"></i>")), '_label -> "What do you prefer?" )
+				@@b3.radio( fooForm("foo"), options = Seq("B" -> Html("Beer <i class=\"fa fa-beer\"></i>"), "C" -> Html("Coffee <i class=\"fa fa-coffee\"></i>")), Symbol("_label") -> "What do you prefer?" )
 			}
 
 			<h5 id="helper-radio-customizable" style="margin-top:40px"><code>b3.radio</code> <span class="def">@@(field: Field, args: (Symbol, Any)*)(content: Tuple6[Boolean, Boolean, String, String, Option[String], Map[Symbol, Any]] => Html)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h5>
@@ -252,14 +252,14 @@
 				If you need more versatility you can fully customize your radio options:
 			</p>
 			@bsExampleWithCode {
-				@b3.radio( fooForm("foo_radio3"), '_label -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
+				@b3.radio( fooForm("foo_radio3"), Symbol("_label") -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
 					@b3.radioOption("B", Html("""Beer <i class="fa fa-beer"></i>"""))
-					@b3.radioOption("B", Html("""Coffee <i class="fa fa-coffee"></i>"""), 'disabled -> true)
+					@b3.radioOption("B", Html("""Coffee <i class="fa fa-coffee"></i>"""), Symbol("disabled") -> true)
 				}
 			}{
-				@@b3.radio( fooForm("foo3"), '_label -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
+				@@b3.radio( fooForm("foo3"), Symbol("_label") -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
 					@@b3.radioOption("B", Html("Beer <i class=\"fa fa-beer\"></i>"))
-					@@b3.radioOption("B", Html("Coffee <i class=\"fa fa-coffee\"></i>"), 'disabled -> true)
+					@@b3.radioOption("B", Html("Coffee <i class=\"fa fa-coffee\"></i>"), Symbol("disabled") -> true)
 				}
 			}
 
@@ -272,19 +272,19 @@
 				one and a <code>&lt;input type="hidden"&gt;</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Disabled", 'disabled -> true )
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Readonly", 'readonly -> true )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Disabled", Symbol("disabled") -> true )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Readonly", Symbol("readonly") -> true )
 			}{
 				@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 
-				@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select" )
+				@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
 
 				// disabled -> it will NOT be sent within the POST request
-				@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select", 'disabled -> true )
+				@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("disabled") -> true )
 
 				// readonly -> it will be sent within the POST request
-				@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select", 'readonly -> true )
+				@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("readonly") -> true )
 			}
 			<p>
 				You can add a default first value using the argument <code>'_default</code> with a string.
@@ -294,11 +294,11 @@
 				and if any other option is selected this default one will not appear at all.
 			</p>
 			@bsExampleWithCode {
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "With default", '_default -> "Select an option" )
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "With default and Pears as value", '_default -> "Select an option", 'value -> "P" )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "With default", Symbol("_default") -> "Select an option" )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "With default and Pears as value", Symbol("_default") -> "Select an option", Symbol("value") -> "P" )
 			}{
-				@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select", '_default -> "Select an option" )
-				@@b3.select( fooForm("foo"), options = fruits, '_label -> "With default and Pears as value", '_default -> "Select an option", 'value -> "P" )
+				@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("_default") -> "Select an option" )
+				@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "With default and Pears as value", Symbol("_default") -> "Select an option", Symbol("value") -> "P" )
 			}
 
 			<p>
@@ -306,15 +306,15 @@
 				In that case, the <code>'_default</code> argument will be ignored.
 			</p>
 			@bsExampleWithCode {
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Select Multiple", 'multiple -> true )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select Multiple", Symbol("multiple") -> true )
 			}{
 				@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 
-				@@b3.select( fooForm("foo"), options = fruits, '_label -> "Fruits", 'multiple -> true )
+				@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Fruits", Symbol("multiple") -> true )
 
 				// with value "A" and "B" by default
 				// it is a string with every value separated by commas
-				@@b3.select( fooForm("foo"), options = fruits, '_label -> "Fruits", 'multiple -> true, 'value -> "A,B" )
+				@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Fruits", Symbol("multiple") -> true, Symbol("value") -> "A,B" )
 			}
 
 			<h5 id="helper-select-customizable" style="margin-top:40px"><code>b3.select</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(content: Set[String] => Html)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h5>
@@ -323,22 +323,22 @@
 				If you need more versatility you can fully customize your select options:
 			</p>
 			@bsExampleWithCode {
-				@b3.select( fooForm("foo"), '_label -> "Grouped select" ) { implicit values =>
+				@b3.select( fooForm("foo"), Symbol("_label") -> "Grouped select" ) { implicit values =>
 				  <optgroup label="Group 1">
 				    @b3.selectOption("opt_1-1", "Option 1.1")
-				    @b3.selectOption("opt_1-2", "Option 1.2", 'disabled -> true)
+				    @b3.selectOption("opt_1-2", "Option 1.2", Symbol("disabled") -> true)
 				    @b3.selectOption("opt_1-3", "Option 1.3")
 				  </optgroup>
 				  <optgroup label="Group 2">
-				    @b3.selectOption("opt_2-1", "Option 2.1", 'disabled -> true)
+				    @b3.selectOption("opt_2-1", "Option 2.1", Symbol("disabled") -> true)
 				    @b3.selectOption("opt_2-2", "Option 2.2")
 				  </optgroup>
 				}
 
-				@b3.select( fooForm("foo"), '_label -> "Fruits select (lemon preselected)" ) { implicit values =>
+				@b3.select( fooForm("foo"), Symbol("_label") -> "Fruits select (lemon preselected)" ) { implicit values =>
 					<optgroup label="Citrus fruits">
 				    @fruitsWithCitrus.filter(_.isCitrus).map { citrus =>
-				      @b3.selectOption(citrus.id, citrus.name, 'selected -> (citrus.name == "Lemon"))
+				      @b3.selectOption(citrus.id, citrus.name, Symbol("selected") -> (citrus.name == "Lemon"))
 				    }
 					</optgroup>
 					<optgroup label="Rest of fruits">
@@ -348,14 +348,14 @@
 					</optgroup>
 				}
 			}{
-				@@b3.select( fooForm("foo"), '_label -> "Grouped select" ) { implicit values =>
+				@@b3.select( fooForm("foo"), Symbol("_label") -> "Grouped select" ) { implicit values =>
 				  <optgroup label="Group 1">
 				    @@b3.selectOption("opt_1-1", "Option 1.1")
-				    @@b3.selectOption("opt_1-2", "Option 1.2", 'disabled -> true)
+				    @@b3.selectOption("opt_1-2", "Option 1.2", Symbol("disabled") -> true)
 				    @@b3.selectOption("opt_1-3", "Option 1.3")
 				  </optgroup>
 				  <optgroup label="Group 2">
-				    @@b3.selectOption("opt_2-1", "Option 2.1", 'disabled -> true)
+				    @@b3.selectOption("opt_2-1", "Option 2.1", Symbol("disabled") -> true)
 				    @@b3.selectOption("opt_2-2", "Option 2.2")
 				  </optgroup>
 				}
@@ -370,10 +370,10 @@
 					Fruit(5L, "Banana", false)
 				)}
 
-				@@b3.select( fooForm("foo"), '_label -> "Fruits select (lemon preselected)" ) { implicit values =>
+				@@b3.select( fooForm("foo"), Symbol("_label") -> "Fruits select (lemon preselected)" ) { implicit values =>
 					<optgroup label="Citrus fruits">
 				    @@fruitsWithCitrus.filter(_.isCitrus).map { citrus =>
-				      @@b3.selectOption(citrus.id, citrus.name, 'selected -> (citrus.name == "Lemon"))
+				      @@b3.selectOption(citrus.id, citrus.name, Symbol("selected") -> (citrus.name == "Lemon"))
 				    }
 					</optgroup>
 					<optgroup label="Rest of fruits">
@@ -390,7 +390,7 @@
 				It simply renders a hidden input.
 			</p>
 			@code {
-				@@b3.hidden("fooName", "fooValue", 'fooAttr -> "fooAttrValue")
+				@@b3.hidden("fooName", "fooValue", Symbol("fooAttr") -> "fooAttrValue")
 			}
 			<p>Renders to:</p>
 			@code {
@@ -406,7 +406,7 @@
         <code>'value</code>. Finally, take into account that every "underscored" argument (with "_" as preffix) will be removed.
       </p>
 			@code {
-				@@b3.hidden( fooForm("name"), '_label -> "Name", 'value -> "defaultValue", 'placeholder -> "John Doe" )
+				@@b3.hidden( fooForm("name"), Symbol("_label") -> "Name", Symbol("value") -> "defaultValue", Symbol("placeholder") -> "John Doe" )
 			}
 			<p>Renders to:</p>
 			@code {
@@ -439,9 +439,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="color"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.color( fooForm("color"), '_label -> "Color", 'value -> "#3264c8" )
+				@b3.color( fooForm("color"), Symbol("_label") -> "Color", Symbol("value") -> "#3264c8" )
 			}{
-				@@b3.color( fooForm("color"), '_label -> "Color", 'value -> "#3264c8" )
+				@@b3.color( fooForm("color"), Symbol("_label") -> "Color", Symbol("value") -> "#3264c8" )
 			}
 
 			<h4 id="html5-date"><code>b3.date</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -449,9 +449,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="date"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.date( fooForm("date"), '_label -> "Date" )
+				@b3.date( fooForm("date"), Symbol("_label") -> "Date" )
 			}{
-				@@b3.date( fooForm("date"), '_label -> "Date" )
+				@@b3.date( fooForm("date"), Symbol("_label") -> "Date" )
 			}
 
 			<h4 id="html5-datetime"><code>b3.datetime</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -459,9 +459,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="datetime"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.datetime( fooForm("datetime"), '_label -> "Datetime" )
+				@b3.datetime( fooForm("datetime"), Symbol("_label") -> "Datetime" )
 			}{
-				@@b3.datetime( fooForm("datetime"), '_label -> "Datetime" )
+				@@b3.datetime( fooForm("datetime"), Symbol("_label") -> "Datetime" )
 			}
 
 			<h4 id="html5-datetime-local"><code>b3.datetimeLocal</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -469,9 +469,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="datetime-local"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.datetimeLocal( fooForm("datetimeLocal"), '_label -> "Datetime-Local" )
+				@b3.datetimeLocal( fooForm("datetimeLocal"), Symbol("_label") -> "Datetime-Local" )
 			}{
-				@@b3.datetimeLocal( fooForm("datetimeLocal"), '_label -> "Datetime-Local" )
+				@@b3.datetimeLocal( fooForm("datetimeLocal"), Symbol("_label") -> "Datetime-Local" )
 			}
 
 			<h4 id="html5-email"><code>b3.email</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -479,9 +479,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="email"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+				@b3.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
 			}{
-				@@b3.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
+				@@b3.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
 			}
 
 			<h4 id="html5-month"><code>b3.month</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -489,9 +489,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="month"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.month( fooForm("month"), '_label -> "Month" )
+				@b3.month( fooForm("month"), Symbol("_label") -> "Month" )
 			}{
-				@@b3.month( fooForm("month"), '_label -> "Month" )
+				@@b3.month( fooForm("month"), Symbol("_label") -> "Month" )
 			}
 
 			<h4 id="html5-number"><code>b3.number</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -499,9 +499,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="number"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.number( fooForm("number"), '_label -> "Number (0 to 50 with intervals of 5)", 'min -> 0, 'max -> 50, 'step -> 5 )
+				@b3.number( fooForm("number"), Symbol("_label") -> "Number (0 to 50 with intervals of 5)", Symbol("min") -> 0, Symbol("max") -> 50, Symbol("step") -> 5 )
 			}{
-				@@b3.number( fooForm("number"), '_label -> "Number", 'min -> 0, 'max -> 50, 'step -> 5 )
+				@@b3.number( fooForm("number"), Symbol("_label") -> "Number", Symbol("min") -> 0, Symbol("max") -> 50, Symbol("step") -> 5 )
 			}
 
 			<h4 id="html5-range"><code>b3.range</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -509,9 +509,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="range"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.range( fooForm("range"), '_label -> "Range (0 to 50)", 'min -> 0, 'max -> 50 )
+				@b3.range( fooForm("range"), Symbol("_label") -> "Range (0 to 50)", Symbol("min") -> 0, Symbol("max") -> 50 )
 			}{
-				@@b3.range( fooForm("range"), '_label -> "Range", 'min -> 0, 'max -> 50 )
+				@@b3.range( fooForm("range"), Symbol("_label") -> "Range", Symbol("min") -> 0, Symbol("max") -> 50 )
 			}
 
 			<h4 id="html5-search"><code>b3.search</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -519,9 +519,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="search"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.search( fooForm("search"), '_label -> "Search" )
+				@b3.search( fooForm("search"), Symbol("_label") -> "Search" )
 			}{
-				@@b3.search( fooForm("search"), '_label -> "Search" )
+				@@b3.search( fooForm("search"), Symbol("_label") -> "Search" )
 			}
 
 			<h4 id="html5-tel"><code>b3.tel</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -529,9 +529,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="tel"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.tel( fooForm("tel"), '_label -> "Telephone" )
+				@b3.tel( fooForm("tel"), Symbol("_label") -> "Telephone" )
 			}{
-				@@b3.tel( fooForm("tel"), '_label -> "Telephone" )
+				@@b3.tel( fooForm("tel"), Symbol("_label") -> "Telephone" )
 			}
 
 			<h4 id="html5-time"><code>b3.time</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -539,9 +539,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="time"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.time( fooForm("time"), '_label -> "Time" )
+				@b3.time( fooForm("time"), Symbol("_label") -> "Time" )
 			}{
-				@@b3.time( fooForm("time"), '_label -> "Time" )
+				@@b3.time( fooForm("time"), Symbol("_label") -> "Time" )
 			}
 
 			<h4 id="html5-url"><code>b3.url</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -549,9 +549,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="url"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.url( fooForm("url"), '_label -> "URL" )
+				@b3.url( fooForm("url"), Symbol("_label") -> "URL" )
 			}{
-				@@b3.url( fooForm("url"), '_label -> "URL" )
+				@@b3.url( fooForm("url"), Symbol("_label") -> "URL" )
 			}
 
 			<h4 id="html5-week"><code>b3.week</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: B3FieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -559,9 +559,9 @@
 				It is a short version of <code>b3.inputType</code> for <code>type="week"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b3.week( fooForm("week"), '_label -> "Week" )
+				@b3.week( fooForm("week"), Symbol("_label") -> "Week" )
 			}{
-				@@b3.week( fooForm("week"), '_label -> "Week" )
+				@@b3.week( fooForm("week"), Symbol("_label") -> "Week" )
 			}
 
 
@@ -595,11 +595,11 @@
 			</p>
 			@bsExampleWithCode {
 				@b3.static(Html("Label with icon <i class=\"fa fa-beer\"></i>")){ <a href="#">Basic control with label</a> }
-				@b3.static("Hidden label", '_hideLabel -> true){ <a href="#">Basic control with hidden label</a> }
+				@b3.static("Hidden label", Symbol("_hideLabel") -> true){ <a href="#">Basic control with hidden label</a> }
 				@b3.static(){ <a href="#">Basic control without label</a> }
 			}{
 				@@b3.static(Html("Label with icon <i class=\"fa fa-beer\"></i>")){ <a href="#">Basic control with label</a> }
-				@@b3.static("Hidden label", '_hideLabel -> true){ <a href="#">Basic control with hidden label</a> }
+				@@b3.static("Hidden label", Symbol("_hideLabel") -> true){ <a href="#">Basic control with hidden label</a> }
 				@@b3.static(){ <a href="#">Basic control without label</a> }
 			}
 
@@ -610,9 +610,9 @@
 				render whatever you want.
 			</p>
 			@bsExampleWithCode {
-				@b3.buttonType("submit", 'class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
+				@b3.buttonType("submit", Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
 			}{
-				@@b3.buttonType("submit", 'class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
+				@@b3.buttonType("submit", Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
 			}
 
 			<h4 id="more-submit"><code>b3.submit</code> <span class="def">@@(args: (Symbol,Any)*)(text: => Html)(implicit fc: B3FieldConstructor)</span></h4>
@@ -620,9 +620,9 @@
 				It is a short version of b3.buttonType for type="submit".
 			</p>
 			@bsExampleWithCode {
-				@b3.submit('class -> "btn btn-primary"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
+				@b3.submit(Symbol("class") -> "btn btn-primary"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
 			}{
-				@@b3.submit('class -> "btn btn-primary"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
+				@@b3.submit(Symbol("class") -> "btn btn-primary"){ <span class="glyphicon glyphicon-ok"></span> Sign in }
 			}
 
 
@@ -631,9 +631,9 @@
 				It is a short version of b3.buttonType for type="reset".
 			</p>
 			@bsExampleWithCode {
-				@b3.reset('class -> "btn btn-danger"){ <span class="glyphicon glyphicon-remove"></span> Reset }
+				@b3.reset(Symbol("class") -> "btn btn-danger"){ <span class="glyphicon glyphicon-remove"></span> Reset }
 			}{
-				@@b3.reset('class -> "btn btn-danger"){ <span class="glyphicon glyphicon-remove"></span> Reset }
+				@@b3.reset(Symbol("class") -> "btn btn-danger"){ <span class="glyphicon glyphicon-remove"></span> Reset }
 			}
 
 			<h4 id="more-button"><code>b3.button</code> <span class="def">@@(args: (Symbol,Any)*)(text: => Html)(implicit fc: B3FieldConstructor)</span></h4>
@@ -641,9 +641,9 @@
 				It is a short version of b3.buttonType for type="button".
 			</p>
 			@bsExampleWithCode {
-				@b3.button('class -> "btn btn-default"){ <span class="glyphicon glyphicon-heart"></span> Favorite }
+				@b3.button(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-heart"></span> Favorite }
 			}{
-				@@b3.button('class -> "btn btn-default"){ <span class="glyphicon glyphicon-heart"></span> Favorite }
+				@@b3.button(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-heart"></span> Favorite }
 			}
 
 
@@ -652,12 +652,12 @@
 				It renders whatever you want within a <code>form-group</code> div.
 			</p>
 			@bsExampleWithCode {
-				@b3.free('_id -> "idFormGroup") {
+				@b3.free(Symbol("_id") -> "idFormGroup") {
 					<button type="submit" class="btn btn-primary"> <span class="glyphicon glyphicon-ok"></span> Save changes</button>
 					<a class="btn btn-default"> <span class="glyphicon glyphicon-remove"></span> Cancel</a>
 				}
 			}{
-				@@b3.free('_id -> "idFormGroup") {
+				@@b3.free(Symbol("_id") -> "idFormGroup") {
 					<button type="submit" class="btn btn-primary"> <span class="glyphicon glyphicon-ok"></span> Save changes</button>
 					<a class="btn btn-default"> <span class="glyphicon glyphicon-remove"></span> Cancel</a>
 				}
@@ -682,7 +682,7 @@
 				It is useful for <strong>input groups</strong> and <strong>inputs with validation states and feedback icons</strong>.
 			</p>
 			@bsExampleWithCode {
-				@b3.inputWrapped( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" ) { input =>
+				@b3.inputWrapped( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" ) { input =>
 					<div class="input-group">
 					  <span class="input-group-addon">@@</span>
 					  @input
@@ -699,7 +699,7 @@
 					</div>
 				}
 			}{
-				@@b3.inputWrapped( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" ) { input =>
+				@@b3.inputWrapped( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" ) { input =>
 				  <div class="input-group">
 				    <span class="input-group-addon">@@@@</span>
 				    @@input

--- a/play27-bootstrap3/sample/app/views/extendIt.scala.html
+++ b/play27-bootstrap3/sample/app/views/extendIt.scala.html
@@ -18,17 +18,17 @@
 
 		<h2 id="create-helper">Create your own helper</h2>
 		@bsExample {
-			@b3.my.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+			@b3.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
 		}
 		@code {
-			@@b3.my.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
+			@@b3.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
 		}
 
 		<h3 id="input-wrapped">The use of <code>b3.inputWrapped</code></h3>
 		@bsExampleWithCode {
-			@b3.my.number( fooForm("foo"), '_label -> "Number", 'value -> 0 )
+			@b3.my.number( fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0 )
 		}{
-			@@b3.my.number( fooForm("foo"), '_label -> "Number", 'value -> 0 )
+			@@b3.my.number( fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0 )
 		}
 
 		<h3 id="multifield">Create your multifield helper</h3>
@@ -39,7 +39,7 @@
 	<h2 id="create-field-constructor">Create your own field constructor</h2>
 	@bsExampleWithCode {
 		@b3.my.vertical.form(routes.Application.extendIt) { implicit myfc =>
-			@b3.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@mail.com" )
+			@b3.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("_error") -> "And error occurred!", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "example@mail.com" )
 		}
 	}{
 		<div class="my-form-group form-group has-error" id="foo_field">
@@ -64,14 +64,14 @@
 	@code {
 		@@import b3.my.vertical.fieldConstructor		// Declare it as default
 
-		@@b3.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@@mail.com" )
+		@@b3.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("_error") -> "And error occurred!", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "example@@mail.com" )
 	}
 	<p>
 		Or even using it for specific forms:
 	</p>
 	@code {
 		@@b3.my.vertical.form(routes.Application.extendIt) { implicit myfc =>
-			@@b3.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@@mail.com" )
+			@@b3.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("_error") -> "And error occurred!", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "example@@mail.com" )
 		}
 	}
 

--- a/play27-bootstrap3/sample/app/views/horizontal.scala.html
+++ b/play27-bootstrap3/sample/app/views/horizontal.scala.html
@@ -14,40 +14,40 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b3.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b3.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
 			</div>
 			<div class="col-md-6">
-				@b3.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-				@b3.file( fooForm("foo"), '_label -> "File" )
+				@b3.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+				@b3.file( fooForm("foo"), Symbol("_label") -> "File" )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b3.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-		@@b3.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-		@@b3.file( fooForm("foo"), '_label -> "File" )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b3.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+		@@b3.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+		@@b3.file( fooForm("foo"), Symbol("_label") -> "File" )
 	}
 
 	<h3 id="more-options">More options</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b3.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-				@b3.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			</div>
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), 'placeholder -> "Without label" )
-				@b3.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control input-lg", 'placeholder -> "An awesome field..." )
+				@b3.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control input-lg", Symbol("placeholder") -> "An awesome field..." )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-		@@b3.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-		@@b3.text( fooForm("foo"), 'placeholder -> "Without label" )
-		@@b3.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control input-lg", 'placeholder -> "An awesome field..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+		@@b3.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control input-lg", Symbol("placeholder") -> "An awesome field..." )
 	}
 
 
@@ -55,79 +55,79 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-				@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-				@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+				@b3.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+				@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+				@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 			</div>
 			<div class="col-md-6">
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 			</div>
 		</div>
 	}{
-		@@b3.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-		@@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-		@@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+		@@b3.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+		@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+		@@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 
 		@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 		...
-		@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-		@@b3.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 	}
 
 	<h3 id="disabled-readonly-attributes">Disabled and readonly attributes</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-				@b3.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+				@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
 			</div>
 			<div class="col-md-6">
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-		@@b3.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-		@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+		@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 	}
 
 	<h3 id="validation-states">Validation states</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			</div>
 			<div class="col-md-6">
-				@b3.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", '_feedbackIcons -> true) { implicit fc =>
-					@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-					@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-					@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", Symbol("_feedbackIcons") -> true) { implicit fc =>
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 				}
-				@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 
 		// With feedback icons
-		@@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 
 		Or
 
 		// With feedback icons
-		@@b3.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", '_feedbackIcons -> true) { implicit fc =>
-			@@b3.text( fooForm("foo"), '_label -> "Success", 'placeholder -> "Success text..." )
-			@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-			@@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", Symbol("_feedbackIcons") -> true) { implicit fc =>
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("placeholder") -> "Success text..." )
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 		}
 	}
 
@@ -135,13 +135,13 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.inputWrapped( "email", fooForm("foo"), '_label -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+				@b3.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 					<div class="input-group">
 						<span class="input-group-addon">@@</span>
 						@input
 					</div>
 				}
-				@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+				@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 					<div class="input-number input-group">
 						<span class="input-group-addon input-number-minus"><span class="glyphicon glyphicon-minus"></span></span>
 						@input
@@ -150,7 +150,7 @@
 				}
 			</div>
 			<div class="col-md-6">
-				@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+				@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 					<div class="input-group">
 						<span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
 						@input
@@ -173,13 +173,13 @@
 			</div>
 		</div>
 	}{
-		@@b3.inputWrapped( "email", fooForm("foo"), '_label -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+		@@b3.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon">@@@@</span>
 				@@input
 			</div>
 		}
-		@@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+		@@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
 				@@input
@@ -188,7 +188,7 @@
 				</div>
 			</div>
 		}
-		@@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+		@@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 			<div class="input-number input-group">
 				<span class="input-group-addon input-number-minus"><span class="glyphicon glyphicon-minus"></span></span>
 				@@input
@@ -202,7 +202,7 @@
 		<div class="row">
 			<div class="col-md-6">
 				@b3.static("Static HTML"){ <a href="#"><span class="glyphicon glyphicon-star"></span> This is a link</a> }
-				@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
+				@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
 				@b3.free() {
 					<button type="submit" class="btn btn-primary"> <span class="glyphicon glyphicon-ok"></span> Save changes</button>
 					<a class="btn btn-default"> <span class="glyphicon glyphicon-remove"></span> Cancel</a>
@@ -211,7 +211,7 @@
 		</div>
 	}{
 		@@b3.static("Static HTML"){ <a href="#"><span class="glyphicon glyphicon-star"></span> This is a link</a> }
-		@@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
+		@@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
 		@@b3.free() {
 			<button type="submit" class="btn btn-primary"> <span class="glyphicon glyphicon-ok"></span> Save changes</button>
 			<a class="btn btn-default"> <span class="glyphicon glyphicon-remove"></span> Cancel</a>

--- a/play27-bootstrap3/sample/app/views/index.scala.html
+++ b/play27-bootstrap3/sample/app/views/index.scala.html
@@ -40,51 +40,51 @@
 		<div class="tab-pane active fade in" id="vertical">
 			@bsExampleWithCode {
 				@b3.vertical.form(routes.Application.index) { implicit vfc =>
-					@b3.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
-					@b3.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@b3.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@b3.submit('class -> "btn btn-default"){ Sign in }
+					@b3.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+					@b3.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@b3.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 				}
 			}{
 				@@b3.vertical.form(routes.Application.index) { implicit vfc =>
-					@@b3.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-					@@b3.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@@b3.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@@b3.submit('class -> "btn btn-default"){ Sign in }
+					@@b3.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+					@@b3.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@@b3.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 				}
 			}
 		</div>
 		<div class="tab-pane fade in" id="horizontal">
 			@bsExampleWithCode {
 				@b3.horizontal.form(routes.Application.index, "col-md-2", "col-md-10") { implicit hfc =>
-					@b3.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
-					@b3.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@b3.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@b3.submit('class -> "btn btn-default"){ Sign in }
+					@b3.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+					@b3.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@b3.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 				}
 			}{
 				@@b3.horizontal.form(routes.Application.index, "col-md-2", "col-md-10") { implicit hfc =>
-					@@b3.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-					@@b3.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@@b3.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@@b3.submit('class -> "btn btn-default"){ Sign in }
+					@@b3.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+					@@b3.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@@b3.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 				}
 			}
 		</div>
 		<div class="tab-pane fade" id="inline">
 			@bsExampleWithCode {
 				@b3.inline.form(routes.Application.index) { implicit ifc =>
-					@b3.email( fooForm("email"), '_hiddenLabel -> "Email", 'placeholder -> "example@mail.com" )
-					@b3.password( fooForm("password"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-					@b3.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@b3.submit('class -> "btn btn-default"){ Sign in }
+					@b3.email( fooForm("email"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+					@b3.password( fooForm("password"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+					@b3.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 				}
 			}{
 				@@b4.inline.form(routes.Application.index) { implicit ifc =>
-					@@b3.email( fooForm("email"), '_hiddenLabel -> "Email", 'placeholder -> "example@@mail.com" )
-					@@b3.password( fooForm("password"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-					@@b3.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@@b3.submit('class -> "btn btn-default"){ Sign in }
+					@@b3.email( fooForm("email"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+					@@b3.password( fooForm("password"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+					@@b3.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 				}
 			}
 		</div>

--- a/play27-bootstrap3/sample/app/views/inline.scala.html
+++ b/play27-bootstrap3/sample/app/views/inline.scala.html
@@ -12,112 +12,112 @@
 
 	<h3 id="simple-inputs">Simple inputs</h3>
 	@bsExampleWithCode {
-		@b3.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-		@b3.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@mail.com" )
-		@b3.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-		@b3.file( fooForm("foo"), '_hiddenLabel -> "File" )
+		@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@b3.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+		@b3.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+		@b3.file( fooForm("foo"), Symbol("_hiddenLabel") -> "File" )
 	}{
-		@@b3.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b3.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@@mail.com" )
-		@@b3.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-		@@b3.file( fooForm("foo"), '_hiddenLabel -> "File" )
+		@@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b3.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+		@@b3.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+		@@b3.file( fooForm("foo"), Symbol("_hiddenLabel") -> "File" )
 	}
 
 	<h3 id="more-options">More options</h3>
 	@bsExampleWithCode {
-		@b3.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-		@b3.text( fooForm("foo"), '_label -> "Show label", '_showLabel -> true, 'placeholder -> "Show label" )
-		@b3.text( fooForm("foo"), '_hiddenLabel -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-		@b3.text( fooForm("foo"), '_hiddenLabel -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-		@b3.text( fooForm("foo"), 'placeholder -> "Without label" )
-		@b3.text( fooForm("foo"), '_hiddenLabel -> "A big text", 'class -> "form-control input-lg", 'placeholder -> "An awesome field..." )
+		@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@b3.text( fooForm("foo"), Symbol("_label") -> "Show label", Symbol("_showLabel") -> true, Symbol("placeholder") -> "Show label" )
+		@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+		@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+		@b3.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+		@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "A big text", Symbol("class") -> "form-control input-lg", Symbol("placeholder") -> "An awesome field..." )
 	}{
-		@@b3.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Show label", '_showLabel -> true, 'placeholder -> "Show label" )
-		@@b3.text( fooForm("foo"), '_hiddenLabel -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-		@@b3.text( fooForm("foo"), '_hiddenLabel -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-		@@b3.text( fooForm("foo"), 'placeholder -> "Without label" )
-		@@b3.text( fooForm("foo"), '_hiddenLabel -> "A big text", 'class -> "form-control input-lg", 'placeholder -> "An awesome field..." )
+		@@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Show label", Symbol("_showLabel") -> true, Symbol("placeholder") -> "Show label" )
+		@@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+		@@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+		@@b3.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+		@@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "A big text", Symbol("class") -> "form-control input-lg", Symbol("placeholder") -> "An awesome field..." )
 	}
 
 
 	<h3 id="textareas-checkboxes-radios-selects">Textareas, checkboxes, radio buttons and selects</h3>
 	@bsExampleWithCode {
-		@b3.textarea( fooForm("foo"), '_hiddenLabel -> "Textarea", 'rows -> 3 )
-		@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
+		@b3.textarea( fooForm("foo"), Symbol("_hiddenLabel") -> "Textarea", Symbol("rows") -> 3 )
+		@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
 		@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female") )
-		@b3.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select" )
-		@b3.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Multiple Select", 'multiple -> true )
+		@b3.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select" )
+		@b3.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Multiple Select", Symbol("multiple") -> true )
 	}{
-		@@b3.textarea( fooForm("foo"), '_hiddenLabel -> "Textarea", 'rows -> 3 )
-		@@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
+		@@b3.textarea( fooForm("foo"), Symbol("_hiddenLabel") -> "Textarea", Symbol("rows") -> 3 )
+		@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
 		@@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female") )
 
 		@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 		...
-		@@b3.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select" )
-		@@b3.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Multiple Select", 'multiple -> true )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select" )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Multiple Select", Symbol("multiple") -> true )
 	}
 
 	<h3 id="disabled-readonly-attributes">Disabled and readonly attributes</h3>
 	@bsExampleWithCode {
-		@b3.text( fooForm("foo"), '_hiddenLabel -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-		@b3.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-		@b3.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+		@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+		@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+		@b3.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 	}{
-		@@b3.text( fooForm("foo"), '_hiddenLabel -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-		@@b3.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-		@@b3.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+		@@b3.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+		@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 	}
 
 	<h3 id="validation-states">Validation states</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			</div>
 			<div class="col-md-6">
-				@b3.inline.form(routes.Application.inline, '_feedbackIcons -> true) { implicit fc =>
-					@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-					@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-					@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.inline.form(routes.Application.inline, Symbol("_feedbackIcons") -> true) { implicit fc =>
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 				}
-				@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 
 		// With feedback icons
-		@@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 
 		Or
 
 		// With feedback icons
-		@@b3.inline.form(routes.Application.inline, '_feedbackIcons -> true) { implicit fc =>
-			@@b3.text( fooForm("foo"), '_label -> "Success", 'placeholder -> "Success text..." )
-			@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-			@@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.inline.form(routes.Application.inline, Symbol("_feedbackIcons") -> true) { implicit fc =>
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("placeholder") -> "Success text..." )
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 		}
 	}
 
 	<h3 id="customize">Customize them</h3>
 	@bsExampleWithCode {
-		@b3.inputWrapped( "email", fooForm("foo"), '_hiddenLabel -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+		@b3.inputWrapped( "email", fooForm("foo"), Symbol("_hiddenLabel") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon">@@</span>
 				@input
 			</div>
 		}
-		@b3.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+		@b3.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
 				@input
@@ -137,7 +137,7 @@
 				</div>
 			</div>
 		}
-		@b3.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Number", 'value -> 0 ) { input =>
+		@b3.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Number", Symbol("value") -> 0 ) { input =>
 			<div class="input-number input-group">
 				<span class="input-group-addon input-number-minus"><span class="glyphicon glyphicon-minus"></span></span>
 				@input
@@ -145,13 +145,13 @@
 			</div>
 		}
 	}{
-		@@b3.inputWrapped( "email", fooForm("foo"), '_hiddenLabel -> "Simple input group", 'placeholder -> "Custom input group for email..." ) { input =>
+		@@b3.inputWrapped( "email", fooForm("foo"), Symbol("_hiddenLabel") -> "Simple input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon">@@@@</span>
 				@@input
 			</div>
 		}
-		@@b3.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+		@@b3.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
 				@@input
@@ -160,7 +160,7 @@
 				</div>
 			</div>
 		}
-		@@b3.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Number", 'value -> 0 ) { input =>
+		@@b3.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Number", Symbol("value") -> 0 ) { input =>
 			<div class="input-number input-group">
 				<span class="input-group-addon input-number-minus"><span class="glyphicon glyphicon-minus"></span></span>
 				@@input
@@ -171,9 +171,9 @@
 
 	<h3 id="more-helpers">More helpers</h3>
 	@bsExampleWithCode {
-		@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
+		@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
 	}{
-		@@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
+		@@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
 	}
 
 }

--- a/play27-bootstrap3/sample/app/views/mixed.scala.html
+++ b/play27-bootstrap3/sample/app/views/mixed.scala.html
@@ -14,17 +14,17 @@
 	<h3 id="simple-form">A simple horizontal form</h3>
 	@bsExampleWithCode {
 		@b3.form(routes.Application.mixed) {
-			@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@b3.select( fooForm("foo"), options = fruits, '_label -> "Select a fruit" )
-			@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-			@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
+			@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select a fruit" )
+			@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+			@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
 		}
 	}{
 		@@b3.form(routes.Application.mixed) {
-			@@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select a fruit" )
-			@@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-			@@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select a fruit" )
+			@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+			@@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
 		}
 	}
 
@@ -32,15 +32,15 @@
 	<h3 id="inline-form">The typical inline login form on top</h3>
 	@bsExampleWithCode {
 		@b3.inline.form(routes.Application.mixed) { implicit ifc =>
-			@b3.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@mail.com" )
-			@b3.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-			@b3.submit('class -> "btn btn-default"){ Sign in }
+			@b3.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+			@b3.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+			@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 		}
 	}{
 		@@b3.inline.form(routes.Application.mixed) { implicit ifc =>
-			@@b3.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@@mail.com" )
-			@@b3.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-			@@b3.submit('class -> "btn btn-default"){ Sign in }
+			@@b3.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+			@@b3.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+			@@b3.submit(Symbol("class") -> "btn btn-default"){ Sign in }
 		}
 	}
 
@@ -50,21 +50,21 @@
 		<div class="row">
 		<div class="col-md-4">
 			@b3.vertical.form(routes.Application.mixed) { implicit vfc =>
-				@b3.text( fooForm("foo"), '_label -> "Your name", 'placeholder -> "Your contact name" )
-				@b3.email( fooForm("foo"), '_label -> "Your email", 'placeholder -> "example@mail.com" )
-				@b3.textarea( fooForm("foo"), '_label -> "What happened?", 'rows -> 3 )
-				@b3.checkbox( fooForm("foo"), '_text -> "Send me a copy to my email", 'checked -> true )
-				@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-envelope"></span> Send }
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Your name", Symbol("placeholder") -> "Your contact name" )
+				@b3.email( fooForm("foo"), Symbol("_label") -> "Your email", Symbol("placeholder") -> "example@mail.com" )
+				@b3.textarea( fooForm("foo"), Symbol("_label") -> "What happened?", Symbol("rows") -> 3 )
+				@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Send me a copy to my email", Symbol("checked") -> true )
+				@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-envelope"></span> Send }
 			}
 		</div>
 		</div>
 	}{
 		@@b3.vertical.form(routes.Application.mixed) { implicit vfc =>
-			@@b3.text( fooForm("foo"), '_label -> "Your name", 'placeholder -> "Your contact name" )
-			@@b3.email( fooForm("foo"), '_label -> "Your email", 'placeholder -> "example@@mail.com" )
-			@@b3.textarea( fooForm("foo"), '_label -> "What happened?", 'rows -> 3 )
-			@@b3.checkbox( fooForm("foo"), '_text -> "Send me a copy to my email", 'checked -> true )
-			@@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-envelope"></span> Send }
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Your name", Symbol("placeholder") -> "Your contact name" )
+			@@b3.email( fooForm("foo"), Symbol("_label") -> "Your email", Symbol("placeholder") -> "example@@mail.com" )
+			@@b3.textarea( fooForm("foo"), Symbol("_label") -> "What happened?", Symbol("rows") -> 3 )
+			@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Send me a copy to my email", Symbol("checked") -> true )
+			@@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-envelope"></span> Send }
 		}
 	}
 
@@ -72,17 +72,17 @@
 	<h3 id="horizontal-form">A different horizontal form</h3>
 	@bsExampleWithCode {
 		@b3.horizontal.form(routes.Application.mixed, "col-lg-4", "col-lg-8") { implicit hfc =>
-			@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@b3.file( fooForm("foo"), '_label -> "File" )
-			@b3.checkbox( fooForm("foo"), '_text -> "Checkbox" )
-			@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
+			@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@b3.file( fooForm("foo"), Symbol("_label") -> "File" )
+			@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox" )
+			@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
 		}
 	}{
 		@@b3.horizontal.form(routes.Application.mixed, "col-lg-4", "col-lg-8") { implicit hfc =>
-			@@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@@b3.file( fooForm("foo"), '_label -> "File" )
-			@@b3.checkbox( fooForm("foo"), '_text -> "Checkbox" )
-			@@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@@b3.file( fooForm("foo"), Symbol("_label") -> "File" )
+			@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox" )
+			@@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Save changes }
 		}
 	}
 
@@ -90,7 +90,7 @@
 	<h3 id="clear-form">A clear field constructor</h3>
 	@bsExampleWithCode {
 		@b3.clear.form(routes.Application.mixed) { implicit cfc =>
-			@b3.inputWrapped( "search", fooForm("foo"), 'placeholder -> "Text to search..." ) { input =>
+			@b3.inputWrapped( "search", fooForm("foo"), Symbol("placeholder") -> "Text to search..." ) { input =>
 				<div class="input-group">
 					<span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span>
 					@input
@@ -102,7 +102,7 @@
 		}
 	}{
 		@@b3.clear.form(routes.Application.mixed) { implicit cfc =>
-			@@b3.inputWrapped( "search", fooForm("foo"), 'placeholder -> "Text to search..." ) { input =>
+			@@b3.inputWrapped( "search", fooForm("foo"), Symbol("placeholder") -> "Text to search..." ) { input =>
 				<div class="input-group">
 					<span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span>
 					@@input

--- a/play27-bootstrap3/sample/app/views/multifield.scala.html
+++ b/play27-bootstrap3/sample/app/views/multifield.scala.html
@@ -19,64 +19,64 @@
 
 		<h3 id="daterange">A date range</h3>
 		@bsExampleWithCode {
-			@b3.datepicker( fooForm("dateStart"), 'value -> "15-11-2014" )(
-				fooForm("dateEnd"), 'value -> "31-12-2014" )(
-				'_label -> "Date range", "data-date-start-date" -> "10-11-2014", '_help -> "Select a date range from 10-11-2014" )
+			@b3.datepicker( fooForm("dateStart"), Symbol("value") -> "15-11-2014" )(
+				fooForm("dateEnd"), Symbol("value") -> "31-12-2014" )(
+				Symbol("_label") -> "Date range", "data-date-start-date" -> "10-11-2014", Symbol("_help") -> "Select a date range from 10-11-2014" )
 		}{
-			@@b3.datepicker( fooForm("dateStart"), 'value -> "31-10-2014" )(
-				fooForm("dateEnd"), 'value -> "31-12-2014" )(
-				'_label -> "Date range", "data-date-start-date" -> "01-01-2014", '_help -> "Select a date range from 10-11-2014" )
+			@@b3.datepicker( fooForm("dateStart"), Symbol("value") -> "31-10-2014" )(
+				fooForm("dateEnd"), Symbol("value") -> "31-12-2014" )(
+				Symbol("_label") -> "Date range", "data-date-start-date" -> "01-01-2014", Symbol("_help") -> "Select a date range from 10-11-2014" )
 		}
 
 		<h3 id="set-checkboxes">A set of checkboxes</h3>
 		@bsExampleWithCode {
 			@b3.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)( '_label -> "Checkboxes", 'class -> "multi-checkbox-list", '_help -> "Mark what you want" )
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)( Symbol("_label") -> "Checkboxes", Symbol("class") -> "multi-checkbox-list", Symbol("_help") -> "Mark what you want" )
 			@b3.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)('_label -> "Inline", 'class -> "multi-checkbox-list inline", '_help -> "Mark what you want")
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)(Symbol("_label") -> "Inline", Symbol("class") -> "multi-checkbox-list inline", Symbol("_help") -> "Mark what you want")
 		}{
 			@@b3.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)('_label -> "Checkboxes", 'class -> "multi-checkbox-list", '_help -> "Mark what you want")
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)(Symbol("_label") -> "Checkboxes", Symbol("class") -> "multi-checkbox-list", Symbol("_help") -> "Mark what you want")
 			@@b3.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)('_label -> "Inline", 'class -> "multi-checkbox-list inline", '_help -> "Mark what you want")
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)(Symbol("_label") -> "Inline", Symbol("class") -> "multi-checkbox-list inline", Symbol("_help") -> "Mark what you want")
 		}
 
 		<h3 id="text-with-checkbox">A textfield with a checkbox addon</h3>
 		@bsExampleWithCode {
-			@b3.textWithCheckbox( fooForm("foo"), 'placeholder -> "a foo value" )( fooForm("fooSelected") )('_label -> "New task" )
+			@b3.textWithCheckbox( fooForm("foo"), Symbol("placeholder") -> "a foo value" )( fooForm("fooSelected") )(Symbol("_label") -> "New task" )
 		}{
-			@@b3.textWithCheckbox( fooForm("foo"), 'placeholder -> "a foo value" )( fooForm("fooSelected") )('_label -> "New task" )
+			@@b3.textWithCheckbox( fooForm("foo"), Symbol("placeholder") -> "a foo value" )( fooForm("fooSelected") )(Symbol("_label") -> "New task" )
 		}
 
 		<h3 id="validation-states">Validation states and feedback icons</h3>
 		@bsExampleWithCode {
-			@b3.datepicker( fooForm("dateStart"), 'value -> "15-11-2014", '_showIconWarning -> true )(
-				fooForm("dateEnd"), 'value -> "31-10-2014", '_showIconWarning -> true )(
-				'_label -> "Date range", '_hasFeedback -> true )
+			@b3.datepicker( fooForm("dateStart"), Symbol("value") -> "15-11-2014", Symbol("_showIconWarning") -> true )(
+				fooForm("dateEnd"), Symbol("value") -> "31-10-2014", Symbol("_showIconWarning") -> true )(
+				Symbol("_label") -> "Date range", Symbol("_hasFeedback") -> true )
 
-			@b3.textWithCheckbox( fooForm("foo"), 'value -> "an incorrect value", '_error -> "The value is incorrect", '_showIconOnError -> true )(
+			@b3.textWithCheckbox( fooForm("foo"), Symbol("value") -> "an incorrect value", Symbol("_error") -> "The value is incorrect", Symbol("_showIconOnError") -> true )(
 				fooForm("fooSelected") )(
-				'_label -> "New task", '_hasFeedback -> true )
+				Symbol("_label") -> "New task", Symbol("_hasFeedback") -> true )
 		}{
-			@@b3.datepicker( fooForm("dateStart"), 'value -> "15-11-2014", '_showIconWarning -> true )(
-				fooForm("dateEnd"), 'value -> "31-10-2014", '_showIconWarning -> true )(
-				'_label -> "Date range", '_hasFeedback -> true )
+			@@b3.datepicker( fooForm("dateStart"), Symbol("value") -> "15-11-2014", Symbol("_showIconWarning") -> true )(
+				fooForm("dateEnd"), Symbol("value") -> "31-10-2014", Symbol("_showIconWarning") -> true )(
+				Symbol("_label") -> "Date range", Symbol("_hasFeedback") -> true )
 
-			@@b3.textWithCheckbox( fooForm("foo"), 'value -> "an incorrect value", '_error -> "The value is incorrect", '_showIconOnError -> true )(
+			@@b3.textWithCheckbox( fooForm("foo"), Symbol("value") -> "an incorrect value", Symbol("_error") -> "The value is incorrect", Symbol("_showIconOnError") -> true )(
 				fooForm("fooSelected") )(
-				'_label -> "New task", '_hasFeedback -> true )
+				Symbol("_label") -> "New task", Symbol("_hasFeedback") -> true )
 		}
 		<p>
 			The CSS needed for this last example:

--- a/play27-bootstrap3/sample/app/views/readonly.scala.html
+++ b/play27-bootstrap3/sample/app/views/readonly.scala.html
@@ -14,21 +14,21 @@
 		<code>checkbox</code>, <code>radio</code> and <code>select</code> helpers.
 	</p>
 
-	@b3.formCSRF(Call("GET", ""), 'id -> "form-readonly") {
+	@b3.formCSRF(Call("GET", ""), Symbol("id") -> "form-readonly") {
 		@bsExampleWithCode {
-			@b3.text( fooForm("text"), '_label -> "Always editable", '_class -> "always-editable", 'value -> "demo text", 'placeholder -> "A simple text..." )
-			@b3.checkbox( fooForm("checkbox"), '_text -> "Checkbox", 'value -> true, 'readonly -> true )
-			@b3.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), 'value -> "M", '_label -> "Radio Group", 'readonly -> true )
-			@b3.select( fooForm("select"), options = fruits, '_label -> "Select", 'value -> "A", 'readonly -> true )
+			@b3.text( fooForm("text"), Symbol("_label") -> "Always editable", Symbol("_class") -> "always-editable", Symbol("value") -> "demo text", Symbol("placeholder") -> "A simple text..." )
+			@b3.checkbox( fooForm("checkbox"), Symbol("_text") -> "Checkbox", Symbol("value") -> true, Symbol("readonly") -> true )
+			@b3.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), Symbol("value") -> "M", Symbol("_label") -> "Radio Group", Symbol("readonly") -> true )
+			@b3.select( fooForm("select"), options = fruits, Symbol("_label") -> "Select", Symbol("value") -> "A", Symbol("readonly") -> true )
 			@b3.free() {
 				<button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-ok"></span> Submit me!</button>
 				<a class="btn btn-primary btn-readonly-unlock locked">Unlock readonly fields</a>
 			}
 		}{
-			@@b3.text( fooForm("text"), '_label -> "Always editable", '_class -> "always-editable", 'value -> "demo text", 'placeholder -> "A simple text..." )
-			@@b3.checkbox( fooForm("checkbox"), '_text -> "Checkbox", 'value -> true, 'readonly -> true )
-			@@b3.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), 'value -> "M", '_label -> "Radio Group", 'readonly -> true )
-			@@b3.select( fooForm("select"), options = fruits, '_label -> "Select", 'value -> "A", 'readonly -> true )
+			@@b3.text( fooForm("text"), Symbol("_label") -> "Always editable", Symbol("_class") -> "always-editable", Symbol("value") -> "demo text", Symbol("placeholder") -> "A simple text..." )
+			@@b3.checkbox( fooForm("checkbox"), Symbol("_text") -> "Checkbox", Symbol("value") -> true, Symbol("readonly") -> true )
+			@@b3.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), Symbol("value") -> "M", Symbol("_label") -> "Radio Group", Symbol("readonly") -> true )
+			@@b3.select( fooForm("select"), options = fruits, Symbol("_label") -> "Select", Symbol("value") -> "A", Symbol("readonly") -> true )
 			@@b3.free() {
 				<button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-ok"></span> Submit me!</button>
 				<a class="btn btn-primary btn-readonly-unlock locked">Unlock readonly fields</a>

--- a/play27-bootstrap3/sample/app/views/vertical.scala.html
+++ b/play27-bootstrap3/sample/app/views/vertical.scala.html
@@ -14,40 +14,40 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b3.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b3.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
 			</div>
 			<div class="col-md-6">
-				@b3.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-				@b3.file( fooForm("foo"), '_label -> "File" )
+				@b3.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+				@b3.file( fooForm("foo"), Symbol("_label") -> "File" )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b3.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-		@@b3.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-		@@b3.file( fooForm("foo"), '_label -> "File" )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b3.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+		@@b3.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+		@@b3.file( fooForm("foo"), Symbol("_label") -> "File" )
 	}
 
 	<h3 id="more-options">More options</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b3.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-				@b3.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			</div>
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), 'placeholder -> "Without label" )
-				@b3.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control input-lg", 'placeholder -> "An awesome field..." )
+				@b3.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control input-lg", Symbol("placeholder") -> "An awesome field..." )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-		@@b3.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-		@@b3.text( fooForm("foo"), 'placeholder -> "Without label" )
-		@@b3.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control input-lg", 'placeholder -> "An awesome field..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+		@@b3.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control input-lg", Symbol("placeholder") -> "An awesome field..." )
 	}
 
 
@@ -55,79 +55,79 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-				@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-				@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+				@b3.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+				@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+				@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 			</div>
 			<div class="col-md-6">
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 			</div>
 		</div>
 	}{
-		@@b3.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-		@@b3.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-		@@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+		@@b3.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+		@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+		@@b3.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 
 		@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 		...
-		@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-		@@b3.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 	}
 
 	<h3 id="disabled-readonly-attributes">Disabled and readonly attributes</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-				@b3.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+				@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
 			</div>
 			<div class="col-md-6">
-				@b3.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+				@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-		@@b3.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-		@@b3.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+		@@b3.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+		@@b3.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 	}
 
 	<h3 id="validation-states">Validation states</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			</div>
 			<div class="col-md-6">
-				@b3.vertical.form(routes.Application.vertical, '_feedbackIcons -> true) { implicit fc =>
-					@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-					@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-					@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.vertical.form(routes.Application.vertical, Symbol("_feedbackIcons") -> true) { implicit fc =>
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+					@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 				}
-				@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-				@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-				@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+				@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			</div>
 		</div>
 	}{
-		@@b3.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 
 		// With feedback icons
-		@@b3.text( fooForm("foo"), '_label -> "Success", '_showIconValid -> true, 'placeholder -> "Success text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_showIconWarning -> true, 'placeholder -> "Warning text..." )
-		@@b3.text( fooForm("foo"), '_label -> "Error", '_showIconOnError -> true, '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_showIconValid") -> true, Symbol("placeholder") -> "Success text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_showIconWarning") -> true, Symbol("placeholder") -> "Warning text..." )
+		@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_showIconOnError") -> true, Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 
 		Or
 
 		// With feedback icons
-		@@b3.vertical.form(routes.Application.vertical, '_feedbackIcons -> true) { implicit fc =>
-			@@b3.text( fooForm("foo"), '_label -> "Success", 'placeholder -> "Success text..." )
-			@@b3.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-			@@b3.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b3.vertical.form(routes.Application.vertical, Symbol("_feedbackIcons") -> true) { implicit fc =>
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("placeholder") -> "Success text..." )
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+			@@b3.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 		}
 	}
 
@@ -136,13 +136,13 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b3.inputWrapped( "email", fooForm("foo"), '_label -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+				@b3.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 					<div class="input-group">
 						<span class="input-group-addon">@@</span>
 						@input
 					</div>
 				}
-				@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+				@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 					<div class="input-number input-group">
 						<span class="input-group-addon input-number-minus"><span class="glyphicon glyphicon-minus"></span></span>
 						@input
@@ -151,7 +151,7 @@
 				}
 			</div>
 			<div class="col-md-6">
-				@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+				@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 					<div class="input-group">
 						<span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
 						@input
@@ -174,13 +174,13 @@
 			</div>
 		</div>
 	}{
-		@@b3.inputWrapped( "email", fooForm("foo"), '_label -> "Simple input group", 'placeholder -> "Custom input group for email..." ) { input =>
+		@@b3.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Simple input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon">@@@@</span>
 				@@input
 			</div>
 		}
-		@@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+		@@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 			<div class="input-group">
 				<span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
 				@@input
@@ -189,7 +189,7 @@
 				</div>
 			</div>
 		}
-		@@b3.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+		@@b3.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 			<div class="input-number input-group">
 				<span class="input-group-addon input-number-minus"><span class="glyphicon glyphicon-minus"></span></span>
 				@@input
@@ -201,14 +201,14 @@
 	<h3 id="more-helpers">More helpers</h3>
 	@bsExampleWithCode {
 		@b3.static("Static HTML"){ <a href="#"><span class="glyphicon glyphicon-star"></span> This is a link</a> }
-		@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
+		@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
 		@b3.free() {
 			<button type="submit" class="btn btn-primary"> <span class="glyphicon glyphicon-ok"></span> Save changes</button>
 			<a class="btn btn-default"> <span class="glyphicon glyphicon-remove"></span> Cancel</a>
 		}
 	}{
 		@@b3.static("Static HTML"){ <a href="#"><span class="glyphicon glyphicon-star"></span> This is a link</a> }
-		@@b3.submit('class -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
+		@@b3.submit(Symbol("class") -> "btn btn-default"){ <span class="glyphicon glyphicon-ok"></span> Submit me! }
 		@@b3.free() {
 			<button type="submit" class="btn btn-primary"> <span class="glyphicon glyphicon-ok"></span> Save changes</button>
 			<a class="btn btn-default"> <span class="glyphicon glyphicon-remove"></span> Cancel</a>

--- a/play27-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/bsFieldConstructorCommon.scala.html
@@ -1,5 +1,5 @@
 @(fieldInfo: b4.B4FieldInfo, inputHtml: Html, extraClasses: Option[String] = None)(wrap: Html => Html)(implicit fc: b4.B4FieldConstructor)
-<div class="form-group @extraClasses @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
+<div class="form-group @extraClasses @fieldInfo.argsMap.get(Symbol("_class")) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
 	@wrap {
 		@inputHtml
 		@fieldInfo.feedbackInfos.map { case (id, text) =>

--- a/play27-bootstrap4/module/app/views/b4/bsFormGroupCommon.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/bsFormGroupCommon.scala.html
@@ -1,9 +1,9 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(wrap: Html => Html)(implicit msgsProv: MessagesProvider)
-@defining(argsMap.get('_id).map(_.toString).orElse(argsMap.get('id).map(_.toString + "_field"))) { idFormField =>
-	<div class="form-group @argsMap.get('_class)" @idFormField.map{id=>id="@id"}>
+@defining(argsMap.get(Symbol("_id")).map(_.toString).orElse(argsMap.get(Symbol("id")).map(_.toString + "_field"))) { idFormField =>
+	<div class="form-group @argsMap.get(Symbol("_class"))" @idFormField.map{id=>id="@id"}>
 		@wrap {
 			@contentHtml
-			@argsMap.get('_help).map { help =>
+			@argsMap.get(Symbol("_help")).map { help =>
 				<small class="form-text text-muted">@bs.Args.msg(help)(msgsProv)</small>
 			}
 		}

--- a/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
@@ -9,9 +9,9 @@
 }
 @defining({
 	val argsMap = args.toMap
-	val textOpt = argsMap.get('_text).map(bs.Args.msg(_)(msgsProv))
-	val value = argsMap.get('value).getOrElse("true").toString
-	val checked = argsMap.get('checked).orElse(field.value.map(_ == value).orElse(argsMap.get('_default))).map(_.toString == "true").getOrElse(false)
+	val textOpt = argsMap.get(Symbol("_text")).map(bs.Args.msg(_)(msgsProv))
+	val value = argsMap.get(Symbol("value")).getOrElse("true").toString
+	val checked = argsMap.get(Symbol("checked")).orElse(field.value.map(_ == value).orElse(argsMap.get(Symbol("_default")))).map(_.toString == "true").getOrElse(false)
 	val containsReadonly = argsMap.contains('readonly)
 	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)

--- a/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
@@ -1,6 +1,6 @@
 @(field: Field, args: (Symbol,Any)*)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
 @displayLabelWithInput(inputClass: String, labelClass: String, textOpt: Option[Any], value: Any, fieldInfo: b4.B4FieldInfo) = {
-	<input type="checkbox" id="@fieldInfo.id" name="@fieldInfo.name" value="@value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, inputClass + (if (textOpt.isEmpty) " position-static" else "")))>
+	<input type="checkbox" id="@fieldInfo.id" name="@fieldInfo.name" value="@value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, Symbol("class"), inputClass + (if (textOpt.isEmpty) " position-static" else "")))>
 	@textOpt.map { text =>
 		<label class="@labelClass" for="@fieldInfo.id">
 			@text

--- a/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
@@ -17,7 +17,7 @@
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
 	(argsMap, textOpt, value, checked, containsReadonly, readonly, disabled)
 }){ case (argsMap, textOpt, value, checked, containsReadonly, readonly, disabled) =>
-	@inputFormGroup(field, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == 'checked), 'checked -> checked, 'disabled -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == 'checked), Symbol("checked") -> checked, Symbol("disabled") -> disabled)) { fieldInfo =>
 		@defining(fieldInfo.isCustom) { isCustom =>
 			<div class="@if(isCustom){custom-control custom-checkbox}else{form-check}@if(containsReadonly){ checkbox-group}">
 				@if(isCustom) {

--- a/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/checkbox.scala.html
@@ -12,12 +12,12 @@
 	val textOpt = argsMap.get(Symbol("_text")).map(bs.Args.msg(_)(msgsProv))
 	val value = argsMap.get(Symbol("value")).getOrElse("true").toString
 	val checked = argsMap.get(Symbol("checked")).orElse(field.value.map(_ == value).orElse(argsMap.get(Symbol("_default")))).map(_.toString == "true").getOrElse(false)
-	val containsReadonly = argsMap.contains('readonly)
-	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
-	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
+	val containsReadonly = argsMap.contains(Symbol("readonly"))
+	val readonly = bs.ArgsMap.isTrue(argsMap, Symbol("readonly"))
+	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, Symbol("disabled"))
 	(argsMap, textOpt, value, checked, containsReadonly, readonly, disabled)
 }){ case (argsMap, textOpt, value, checked, containsReadonly, readonly, disabled) =>
-	@inputFormGroup(field, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == 'checked), Symbol("checked") -> checked, Symbol("disabled") -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withLabelFor = false, bs.Args.withDefault(args.filterNot(_._1 == Symbol("checked")), Symbol("checked") -> checked, Symbol("disabled") -> disabled)) { fieldInfo =>
 		@defining(fieldInfo.isCustom) { isCustom =>
 			<div class="@if(isCustom){custom-control custom-checkbox}else{form-check}@if(containsReadonly){ checkbox-group}">
 				@if(isCustom) {

--- a/play27-bootstrap4/module/app/views/b4/clear/package.scala
+++ b/play27-bootstrap4/module/app/views/b4/clear/package.scala
@@ -55,11 +55,11 @@ package object clear {
    * *********************************************************************************************************************************
    */
   def form(action: Call, args: (Symbol, Any)*)(body: ClearFieldConstructor => Html) = {
-    val cfc = fieldConstructorSpecific(isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val cfc = fieldConstructorSpecific(isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.form(action, inner(args): _*)(body(cfc))(cfc)
   }
   def formCSRF(action: Call, args: (Symbol, Any)*)(body: ClearFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val cfc = fieldConstructorSpecific(isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val cfc = fieldConstructorSpecific(isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.formCSRF(action, inner(args): _*)(body(cfc))(cfc, request)
   }
 

--- a/play27-bootstrap4/module/app/views/b4/file.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/file.scala.html
@@ -2,10 +2,10 @@
 @inputFormGroup(field, withLabelFor = true, args) { fieldInfo =>
 	@if(fieldInfo.isCustom) {
     <div class="custom-file">
-      <input type="file" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, "custom-file-input"))>
+      <input type="file" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, Symbol("class"), "custom-file-input"))>
       <label class="custom-file-label">@fieldInfo.innerArgsMap.get(Symbol("placeholder"))</label>
     </div>
   } else {
-    <input type="file" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, "form-control-file"))>
+    <input type="file" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, Symbol("class"), "form-control-file"))>
 	}
 }(fc, msgsProv)

--- a/play27-bootstrap4/module/app/views/b4/file.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/file.scala.html
@@ -3,7 +3,7 @@
 	@if(fieldInfo.isCustom) {
     <div class="custom-file">
       <input type="file" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, "custom-file-input"))>
-      <label class="custom-file-label">@fieldInfo.innerArgsMap.get('placeholder)</label>
+      <label class="custom-file-label">@fieldInfo.innerArgsMap.get(Symbol("placeholder"))</label>
     </div>
   } else {
     <input type="file" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, "form-control-file"))>

--- a/play27-bootstrap4/module/app/views/b4/form.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/form.scala.html
@@ -1,4 +1,4 @@
 @(action: Call, args: (Symbol, Any)*)(body: => Html)(implicit fc: b4.B4FieldConstructor)
-<form action="@action.toString" method="@action.method" @toHtmlArgs(bs.Args.withAddingStringValue(bs.Args.inner(args, Symbol("role") -> "form"), 'class, if (bs.Args.isTrue(args, '_disableDefaultClass)) None else Some(fc.formClass)).toMap)>
+<form action="@action.toString" method="@action.method" @toHtmlArgs(bs.Args.withAddingStringValue(bs.Args.inner(args, Symbol("role") -> "form"), 'class, if (bs.Args.isTrue(args, Symbol("_disableDefaultClass"))) None else Some(fc.formClass)).toMap)>
 	@body
 </form>

--- a/play27-bootstrap4/module/app/views/b4/form.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/form.scala.html
@@ -1,4 +1,4 @@
 @(action: Call, args: (Symbol, Any)*)(body: => Html)(implicit fc: b4.B4FieldConstructor)
-<form action="@action.toString" method="@action.method" @toHtmlArgs(bs.Args.withAddingStringValue(bs.Args.inner(args, 'role -> "form"), 'class, if (bs.Args.isTrue(args, '_disableDefaultClass)) None else Some(fc.formClass)).toMap)>
+<form action="@action.toString" method="@action.method" @toHtmlArgs(bs.Args.withAddingStringValue(bs.Args.inner(args, Symbol("role") -> "form"), 'class, if (bs.Args.isTrue(args, '_disableDefaultClass)) None else Some(fc.formClass)).toMap)>
 	@body
 </form>

--- a/play27-bootstrap4/module/app/views/b4/form.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/form.scala.html
@@ -1,4 +1,4 @@
 @(action: Call, args: (Symbol, Any)*)(body: => Html)(implicit fc: b4.B4FieldConstructor)
-<form action="@action.toString" method="@action.method" @toHtmlArgs(bs.Args.withAddingStringValue(bs.Args.inner(args, Symbol("role") -> "form"), 'class, if (bs.Args.isTrue(args, Symbol("_disableDefaultClass"))) None else Some(fc.formClass)).toMap)>
+<form action="@action.toString" method="@action.method" @toHtmlArgs(bs.Args.withAddingStringValue(bs.Args.inner(args, Symbol("role") -> "form"), Symbol("class"), if (bs.Args.isTrue(args, Symbol("_disableDefaultClass"))) None else Some(fc.formClass)).toMap)>
 	@body
 </form>

--- a/play27-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
@@ -1,6 +1,6 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any], colLabel: String, colOffset: String, colInput: String)(implicit msgsProv: MessagesProvider)
 @b4.bsFormGroupCommon(contentHtml, bs.ArgsMap.withAddingStringValue(argsMap, '_class, "row")) { content =>
-	@argsMap.get('_label).map { label =>
+	@argsMap.get(Symbol("_label")).map { label =>
 		<label class="col-form-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(msgsProv)</label>
 		<div class="@colInput">
 			@content

--- a/play27-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
@@ -1,5 +1,5 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any], colLabel: String, colOffset: String, colInput: String)(implicit msgsProv: MessagesProvider)
-@b4.bsFormGroupCommon(contentHtml, bs.ArgsMap.withAddingStringValue(argsMap, '_class, "row")) { content =>
+@b4.bsFormGroupCommon(contentHtml, bs.ArgsMap.withAddingStringValue(argsMap, Symbol("_class"), "row")) { content =>
 	@argsMap.get(Symbol("_label")).map { label =>
 		<label class="col-form-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, Symbol("_hideLabel"))){ sr-only}">@bs.Args.msg(label)(msgsProv)</label>
 		<div class="@colInput">

--- a/play27-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/horizontal/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any], colLabel: String, colOffset: String, colInput: String)(implicit msgsProv: MessagesProvider)
 @b4.bsFormGroupCommon(contentHtml, bs.ArgsMap.withAddingStringValue(argsMap, '_class, "row")) { content =>
 	@argsMap.get(Symbol("_label")).map { label =>
-		<label class="col-form-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ sr-only}">@bs.Args.msg(label)(msgsProv)</label>
+		<label class="col-form-label @colLabel@if(bs.ArgsMap.isTrue(argsMap, Symbol("_hideLabel"))){ sr-only}">@bs.Args.msg(label)(msgsProv)</label>
 		<div class="@colInput">
 			@content
 		</div>

--- a/play27-bootstrap4/module/app/views/b4/horizontal/package.scala
+++ b/play27-bootstrap4/module/app/views/b4/horizontal/package.scala
@@ -58,11 +58,11 @@ package object horizontal {
    * *********************************************************************************************************************************
    */
   def form(action: Call, colLabel: String, colInput: String, args: (Symbol, Any)*)(body: HorizontalFieldConstructor => Html) = {
-    val hfc = fieldConstructorSpecific(colLabel, colInput, isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val hfc = fieldConstructorSpecific(colLabel, colInput, isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.form(action, inner(args): _*)(body(hfc))(hfc)
   }
   def formCSRF(action: Call, colLabel: String, colInput: String, args: (Symbol, Any)*)(body: HorizontalFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val hfc = fieldConstructorSpecific(colLabel, colInput, isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val hfc = fieldConstructorSpecific(colLabel, colInput, isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.formCSRF(action, inner(args): _*)(body(hfc))(hfc, request)
   }
 

--- a/play27-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit msgsProv: MessagesProvider)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get(Symbol("_label")).map { label =>
-		<label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ class="sr-only"}>@bs.Args.msg(label)(msgsProv)</label>
+		<label@if(bs.ArgsMap.isTrue(argsMap, Symbol("_hideLabel"))){ class="sr-only"}>@bs.Args.msg(label)(msgsProv)</label>
 	}
 	@content
 }

--- a/play27-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/inline/bsFormGroup.scala.html
@@ -1,6 +1,6 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit msgsProv: MessagesProvider)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
-	@argsMap.get('_label).map { label =>
+	@argsMap.get(Symbol("_label")).map { label =>
 		<label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ class="sr-only"}>@bs.Args.msg(label)(msgsProv)</label>
 	}
 	@content

--- a/play27-bootstrap4/module/app/views/b4/inline/package.scala
+++ b/play27-bootstrap4/module/app/views/b4/inline/package.scala
@@ -55,11 +55,11 @@ package object inline {
    * *********************************************************************************************************************************
    */
   def form(action: Call, args: (Symbol, Any)*)(body: InlineFieldConstructor => Html) = {
-    val ifc = fieldConstructorSpecific(isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val ifc = fieldConstructorSpecific(isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.form(action, inner(args): _*)(body(ifc))(ifc)
   }
   def formCSRF(action: Call, args: (Symbol, Any)*)(body: InlineFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val ifc = fieldConstructorSpecific(isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val ifc = fieldConstructorSpecific(isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.formCSRF(action, inner(args): _*)(body(ifc))(ifc, request)
   }
 

--- a/play27-bootstrap4/module/app/views/b4/inputWrapped.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/inputWrapped.scala.html
@@ -1,5 +1,5 @@
 @(inputType: String, field: Field, args: (Symbol,Any)*)(inputGroup: Html => Html)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
-@inputFormGroup(field, withLabelFor = true, bs.Args.withAddingStringValue(args, 'class, "form-control")) { fieldInfo =>
+@inputFormGroup(field, withLabelFor = true, bs.Args.withAddingStringValue(args, Symbol("class"), "form-control")) { fieldInfo =>
 	@inputGroup {
     <input type="@inputType" id="@fieldInfo.id" name="@fieldInfo.name" value="@fieldInfo.value" @toHtmlArgs(fieldInfo.innerArgsMap)>
 	}

--- a/play27-bootstrap4/module/app/views/b4/package.scala
+++ b/play27-bootstrap4/module/app/views/b4/package.scala
@@ -72,7 +72,7 @@ package object b4 {
           Symbol("id"), Symbol("value")
         ).map {
             case arg if arg._1 == Symbol("placeholder") => Args.msg(arg)(msgsProv.messages)
-            case other                         => other
+            case other                                  => other
           }
       )
     ).toMap

--- a/play27-bootstrap4/module/app/views/b4/package.scala
+++ b/play27-bootstrap4/module/app/views/b4/package.scala
@@ -46,7 +46,7 @@ package object b4 {
     }
 
     /* Indicates if it's a custom element */
-    def isCustom(implicit fc: b4.B4FieldConstructor): Boolean = fc.isCustom || isTrue(argsMap, '_custom)
+    def isCustom(implicit fc: b4.B4FieldConstructor): Boolean = fc.isCustom || isTrue(argsMap, Symbol("_custom"))
 
     /* The optional validation state ("success", "warning" or "danger") */
     override lazy val status: Option[String] = B4FieldInfo.status(hasErrors, argsMap)
@@ -68,10 +68,10 @@ package object b4 {
       BSFieldInfo.constraintsArgs(field, msgsProv) ++
       Args.inner(
         Args.remove(
-          status.map(s => Args.withAddingStringValue(args, 'class, if (s == "danger") "is-invalid" else if (s == "success") "is-valid" else if (s == "warning") "is-warning" else "")).getOrElse(args),
-          'id, 'value
+          status.map(s => Args.withAddingStringValue(args, Symbol("class"), if (s == "danger") "is-invalid" else if (s == "success") "is-valid" else if (s == "warning") "is-warning" else "")).getOrElse(args),
+          Symbol("id"), Symbol("value")
         ).map {
-            case arg if arg._1 == 'placeholder => Args.msg(arg)(msgsProv.messages)
+            case arg if arg._1 == Symbol("placeholder") => Args.msg(arg)(msgsProv.messages)
             case other                         => other
           }
       )
@@ -86,9 +86,9 @@ package object b4 {
     def status(hasErrors: Boolean, argsMap: Map[Symbol, Any]): Option[String] = {
       if (hasErrors)
         Some("danger")
-      else if (ArgsMap.isNotFalse(argsMap, '_warning))
+      else if (ArgsMap.isNotFalse(argsMap, Symbol("_warning")))
         Some("warning")
-      else if (ArgsMap.isNotFalse(argsMap, '_success))
+      else if (ArgsMap.isNotFalse(argsMap, Symbol("_success")))
         Some("success")
       else
         None
@@ -134,8 +134,8 @@ package object b4 {
     def statusB4Feedback(implicit fc: b4.B4FieldConstructor): Option[String] = B4FieldInfo.statusB4Feedback(status, fc.withFeedbackTooltip)
 
     override lazy val globalArgs = {
-      val withoutHelp = Args.remove(globalArguments, '_help)
-      val withStatus = status.map(s => Args.withDefault(withoutHelp, '_class -> s"has-$s")).getOrElse(withoutHelp)
+      val withoutHelp = Args.remove(globalArguments, Symbol("_help"))
+      val withStatus = status.map(s => Args.withDefault(withoutHelp, Symbol("_class") -> s"has-$s")).getOrElse(withoutHelp)
       withStatus
     }
   }
@@ -194,7 +194,7 @@ package object b4 {
   def week(field: Field, args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = inputType("week", field, args: _*)(fc, msgsProv)
 
   def hidden(name: String, value: Any, args: (Symbol, Any)*) = hiddenInput(name, value, args: _*)
-  def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, 'value)), (bs.Args.inner(bs.Args.remove(args, 'value))): _*)
+  def hidden(field: Field, args: (Symbol, Any)*) = hiddenInput(name = field.name, value = field.value.orElse(bs.Args.get(args, Symbol("value"))), (bs.Args.inner(bs.Args.remove(args, Symbol("value")))): _*)
 
   def radio(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, B4FieldInfo] => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = radioWithContent(field, args: _*)(content)(fc, msgsProv)
   def radio(field: Field, options: Seq[(String, Any)], args: (Symbol, Any)*)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = radioWithOptions(field, options, args: _*)(fc, msgsProv)
@@ -207,8 +207,8 @@ package object b4 {
   def button(args: (Symbol, Any)*)(text: => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = buttonType("button", args: _*)(text)(fc, msgsProv)
 
   def static(args: (Symbol, Any)*)(text: => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = staticBasic(args: _*)(text)(fc, msgsProv)
-  def static(label: String, args: (Symbol, Any)*)(text: => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, '_label -> label): _*)(text)(fc, msgsProv)
-  def static(label: Html, args: (Symbol, Any)*)(text: => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, '_label -> label): _*)(text)(fc, msgsProv)
+  def static(label: String, args: (Symbol, Any)*)(text: => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, Symbol("_label") -> label): _*)(text)(fc, msgsProv)
+  def static(label: Html, args: (Symbol, Any)*)(text: => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = staticBasic(Args.withDefault(args, Symbol("_label") -> label): _*)(text)(fc, msgsProv)
 
   def free(args: (Symbol, Any)*)(content: => Html)(implicit fc: B4FieldConstructor, msgsProv: MessagesProvider) = freeFormGroup(args)(_ => content)(fc, msgsProv)
 

--- a/play27-bootstrap4/module/app/views/b4/radioOption.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/radioOption.scala.html
@@ -1,6 +1,6 @@
 @(inputValue: Any, label: Any, args: (Symbol, Any)*)(implicit extraInfo: (Boolean, Boolean, B4FieldInfo), fc: B4FieldConstructor, msgsProv: MessagesProvider)
 @displayLabelWithInput(inputClass: String, labelClass: String, fieldInfo: b4.B4FieldInfo) = {
-	<input type="radio" id="@(fieldInfo.id)_@inputValue" name="@fieldInfo.name" value="@inputValue"@if(fieldInfo.value == Some(inputValue)){ checked} @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap ++ args.toMap, 'class, inputClass))>
+	<input type="radio" id="@(fieldInfo.id)_@inputValue" name="@fieldInfo.name" value="@inputValue"@if(fieldInfo.value == Some(inputValue)){ checked} @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap ++ args.toMap, Symbol("class"), inputClass))>
   <label class="@labelClass" for="@(fieldInfo.id)_@inputValue">
 		@bs.Args.msg(label)(msgsProv)
 	</label>

--- a/play27-bootstrap4/module/app/views/b4/radioWithContent.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/radioWithContent.scala.html
@@ -14,7 +14,7 @@
 	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
 	(argsMap, inline, disabled)
 }) { case (argsMap, inline, disabled) =>
-	@inputFormGroup(field, withLabelFor = false, bs.Args.withDefault(args, 'disabled -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withLabelFor = false, bs.Args.withDefault(args, Symbol("disabled") -> disabled)) { fieldInfo =>
 		@readonlyWrapper(fieldInfo.name, fieldInfo.value, argsMap, disabled) {
 			@content(inline, disabled, fieldInfo)
 		}

--- a/play27-bootstrap4/module/app/views/b4/radioWithContent.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/radioWithContent.scala.html
@@ -3,7 +3,7 @@
 	@if(argsMap.contains('readonly)) {
 		<div class="radio-group">
 			@contentWrapped
-			<input type="hidden" name="@name" value="@{value.orElse(argsMap.get('_hiddenValue)).get}"@if(!disabled){ disabled}/>
+			<input type="hidden" name="@name" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
 		</div>
 	} else { @contentWrapped }
 }

--- a/play27-bootstrap4/module/app/views/b4/radioWithContent.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/radioWithContent.scala.html
@@ -1,6 +1,6 @@
 @(field: Field, args: (Symbol, Any)*)(content: Tuple3[Boolean, Boolean, b4.B4FieldInfo] => Html)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
 @readonlyWrapper(name: String, value: Option[String], argsMap: Map[Symbol, Any], disabled: Boolean)(contentWrapped: Html) = {
-	@if(argsMap.contains('readonly)) {
+	@if(argsMap.contains(Symbol("readonly"))) {
 		<div class="radio-group">
 			@contentWrapped
 			<input type="hidden" name="@name" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
@@ -9,9 +9,9 @@
 }
 @defining({
 	val argsMap = args.toMap
-	val inline = bs.ArgsMap.isTrue(argsMap, '_inline) || fc.formClass == "form-inline"
-	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
-	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
+	val inline = bs.ArgsMap.isTrue(argsMap, Symbol("_inline")) || fc.formClass == "form-inline"
+	val readonly = bs.ArgsMap.isTrue(argsMap, Symbol("readonly"))
+	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, Symbol("disabled"))
 	(argsMap, inline, disabled)
 }) { case (argsMap, inline, disabled) =>
 	@inputFormGroup(field, withLabelFor = false, bs.Args.withDefault(args, Symbol("disabled") -> disabled)) { fieldInfo =>

--- a/play27-bootstrap4/module/app/views/b4/radioWithOptions.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/radioWithOptions.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, options: Seq[(String, Any)], args: (Symbol, Any)*)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
-@radioWithContent(field, bs.Args.withDefault(args, '_hiddenValue -> options.headOption.map(_._1)):_*) { implicit extraInfo =>
+@radioWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> options.headOption.map(_._1)):_*) { implicit extraInfo =>
 	@options.map { v =>
 		@radioOption(v._1, v._2)
 	}

--- a/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
@@ -22,7 +22,7 @@
 				case _ => fieldInfo.value.toSet
 			}){ implicit values =>
 				@readonlyWrapper(selectName, fieldInfo.value, disabled, argsMap) {
-					<select id="@fieldInfo.id" name="@selectName" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, if (fieldInfo.isCustom) "custom-select" else "form-control"))>
+					<select id="@fieldInfo.id" name="@selectName" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, Symbol("class"), if (fieldInfo.isCustom) "custom-select" else "form-control"))>
 						@argsMap.get(Symbol("_default")).map { v =>
 							@selectOption("", v, Symbol("class") -> "blank", Symbol("selected") -> true, Symbol("disabled") -> "disabled")
 						}

--- a/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
@@ -3,7 +3,7 @@
 	@if(argsMap.contains('readonly)) {
 		<div class="select-group">
 			@contentWrapped
-			<input type="hidden" name="@selectName" value="@{value.orElse(argsMap.get('_hiddenValue)).get}"@if(!disabled){ disabled}/>
+			<input type="hidden" name="@selectName" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
 		</div>
 	} else { @contentWrapped }
 }
@@ -23,7 +23,7 @@
 			}){ implicit values =>
 				@readonlyWrapper(selectName, fieldInfo.value, disabled, argsMap) {
 					<select id="@fieldInfo.id" name="@selectName" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, if (fieldInfo.isCustom) "custom-select" else "form-control"))>
-						@argsMap.get('_default).map { v =>
+						@argsMap.get(Symbol("_default")).map { v =>
 							@selectOption("", v, Symbol("class") -> "blank", Symbol("selected") -> true, Symbol("disabled") -> "disabled")
 						}
 						@content(values)

--- a/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
@@ -1,6 +1,6 @@
 @(field: Field, args: (Symbol,Any)*)(content: Set[String] => Html)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
 @readonlyWrapper(selectName: String, value: Option[String], disabled: Boolean, argsMap: Map[Symbol, Any])(contentWrapped: Html) = {
-	@if(argsMap.contains('readonly)) {
+	@if(argsMap.contains(Symbol("readonly"))) {
 		<div class="select-group">
 			@contentWrapped
 			<input type="hidden" name="@selectName" value="@{value.orElse(argsMap.get(Symbol("_hiddenValue"))).get}"@if(!disabled){ disabled}/>
@@ -9,9 +9,9 @@
 }
 @defining({
 	val argsMap = args.toMap
-	val readonly = bs.ArgsMap.isTrue(argsMap, 'readonly)
-	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, 'disabled)
-	val multiple = bs.ArgsMap.isTrue(argsMap, 'multiple)
+	val readonly = bs.ArgsMap.isTrue(argsMap, Symbol("readonly"))
+	val disabled = readonly || bs.ArgsMap.isTrue(argsMap, Symbol("disabled"))
+	val multiple = bs.ArgsMap.isTrue(argsMap, Symbol("multiple"))
 	(argsMap, disabled, multiple)
 }) { case (argsMap, disabled, multiple) =>
 	@inputFormGroup(field, withLabelFor = true, bs.Args.withDefault(args, Symbol("disabled") -> disabled)) { fieldInfo =>

--- a/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/selectWithContent.scala.html
@@ -14,7 +14,7 @@
 	val multiple = bs.ArgsMap.isTrue(argsMap, 'multiple)
 	(argsMap, disabled, multiple)
 }) { case (argsMap, disabled, multiple) =>
-	@inputFormGroup(field, withLabelFor = true, bs.Args.withDefault(args, 'disabled -> disabled)) { fieldInfo =>
+	@inputFormGroup(field, withLabelFor = true, bs.Args.withDefault(args, Symbol("disabled") -> disabled)) { fieldInfo =>
 		@defining( if(multiple) "%s[]".format(fieldInfo.name) else fieldInfo.name ) { selectName =>
 			@defining( ( !field.indexes.isEmpty && multiple ) match {
 				case true => field.indexes.map( i => field("[%s]".format(i)).value ).flatten.toSet
@@ -24,7 +24,7 @@
 				@readonlyWrapper(selectName, fieldInfo.value, disabled, argsMap) {
 					<select id="@fieldInfo.id" name="@selectName" @toHtmlArgs(bs.ArgsMap.withAddingStringValue(fieldInfo.innerArgsMap, 'class, if (fieldInfo.isCustom) "custom-select" else "form-control"))>
 						@argsMap.get('_default).map { v =>
-							@selectOption("", v, 'class -> "blank", 'selected -> true, 'disabled -> "disabled")
+							@selectOption("", v, Symbol("class") -> "blank", Symbol("selected") -> true, Symbol("disabled") -> "disabled")
 						}
 						@content(values)
 					</select>

--- a/play27-bootstrap4/module/app/views/b4/selectWithOptions.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/selectWithOptions.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
-@selectWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> bs.Args.get(args, '_default).orElse(options.headOption.map(_._1))):_*) { implicit values =>
+@selectWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> bs.Args.get(args, Symbol("_default")).orElse(options.headOption.map(_._1))):_*) { implicit values =>
 	@options.map { v =>
 		@selectOption(v._1, v._2)
 	}

--- a/play27-bootstrap4/module/app/views/b4/selectWithOptions.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/selectWithOptions.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
-@selectWithContent(field, bs.Args.withDefault(args, '_hiddenValue -> bs.Args.get(args, '_default).orElse(options.headOption.map(_._1))):_*) { implicit values =>
+@selectWithContent(field, bs.Args.withDefault(args, Symbol("_hiddenValue") -> bs.Args.get(args, '_default).orElse(options.headOption.map(_._1))):_*) { implicit values =>
 	@options.map { v =>
 		@selectOption(v._1, v._2)
 	}

--- a/play27-bootstrap4/module/app/views/b4/staticBasic.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/staticBasic.scala.html
@@ -1,4 +1,4 @@
 @(args: (Symbol,Any)*)(text: => Html)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
-@freeFormGroup(bs.Args.withAddingStringValue(args, 'class, "form-control-static")) { innerArgsMap =>
+@freeFormGroup(bs.Args.withAddingStringValue(args, Symbol("class"), "form-control-static")) { innerArgsMap =>
 	<p @toHtmlArgs(innerArgsMap)>@text</p>
 }(fc, msgsProv)

--- a/play27-bootstrap4/module/app/views/b4/textarea.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/textarea.scala.html
@@ -1,4 +1,4 @@
 @(field: Field, args: (Symbol,Any)*)(implicit fc: b4.B4FieldConstructor, msgsProv: MessagesProvider)
-@inputFormGroup(field, withLabelFor = true, bs.Args.withAddingStringValue(args, 'class, "form-control")) { fieldInfo =>
+@inputFormGroup(field, withLabelFor = true, bs.Args.withAddingStringValue(args, Symbol("class"), "form-control")) { fieldInfo =>
     <textarea id="@fieldInfo.id" name="@fieldInfo.name" @toHtmlArgs(fieldInfo.innerArgsMap)>@fieldInfo.value</textarea>
 }(fc, msgsProv)

--- a/play27-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
@@ -1,7 +1,7 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit msgsProv: MessagesProvider)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
 	@argsMap.get(Symbol("_label")).map { label =>
-		<label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ class="sr-only"}>@bs.Args.msg(label)(msgsProv)</label>
+		<label@if(bs.ArgsMap.isTrue(argsMap, Symbol("_hideLabel"))){ class="sr-only"}>@bs.Args.msg(label)(msgsProv)</label>
 	}
 	@content
 }

--- a/play27-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
+++ b/play27-bootstrap4/module/app/views/b4/vertical/bsFormGroup.scala.html
@@ -1,6 +1,6 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit msgsProv: MessagesProvider)
 @b4.bsFormGroupCommon(contentHtml, argsMap) { content =>
-	@argsMap.get('_label).map { label =>
+	@argsMap.get(Symbol("_label")).map { label =>
 		<label@if(bs.ArgsMap.isTrue(argsMap, '_hideLabel)){ class="sr-only"}>@bs.Args.msg(label)(msgsProv)</label>
 	}
 	@content

--- a/play27-bootstrap4/module/app/views/b4/vertical/package.scala
+++ b/play27-bootstrap4/module/app/views/b4/vertical/package.scala
@@ -55,11 +55,11 @@ package object vertical {
    * *********************************************************************************************************************************
    */
   def form(action: Call, args: (Symbol, Any)*)(body: VerticalFieldConstructor => Html) = {
-    val vfc = fieldConstructorSpecific(isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val vfc = fieldConstructorSpecific(isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.form(action, inner(args): _*)(body(vfc))(vfc)
   }
   def formCSRF(action: Call, args: (Symbol, Any)*)(body: VerticalFieldConstructor => Html)(implicit request: RequestHeader) = {
-    val vfc = fieldConstructorSpecific(isCustom = isTrue(args, '_custom), withFeedbackTooltip = isTrue(args, '_feedbackTooltip))
+    val vfc = fieldConstructorSpecific(isCustom = isTrue(args, Symbol("_custom")), withFeedbackTooltip = isTrue(args, Symbol("_feedbackTooltip")))
     views.html.b4.formCSRF(action, inner(args): _*)(body(vfc))(vfc, request)
   }
 

--- a/play27-bootstrap4/module/test/FieldConstructorsSpec.scala
+++ b/play27-bootstrap4/module/test/FieldConstructorsSpec.scala
@@ -74,21 +74,21 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow setting a custom id" in {
-      simpleInputWithArgs('_id -> "customid") must contain("id=\"customid\"")
+      simpleInputWithArgs(Symbol("_id") -> "customid") must contain("id=\"customid\"")
     }
 
     "allow setting extra classes form-group" in {
-      clean(simpleInputWithArgs('_class -> "extra_class another_class")) must contain(s"""<div class="form-group$fieldsetExtraClasses extra_class another_class" """)
+      clean(simpleInputWithArgs(Symbol("_class") -> "extra_class another_class")) must contain(s"""<div class="form-group$fieldsetExtraClasses extra_class another_class" """)
     }
 
     "render the label" in {
-      clean(simpleInputWithArgs('_label -> "theLabel")) must contain(if (labelExtraClasses == "") """<label for="foo">theLabel</label>""" else s"""<label class="$labelExtraClasses" for="foo">theLabel</label>""")
+      clean(simpleInputWithArgs(Symbol("_label") -> "theLabel")) must contain(if (labelExtraClasses == "") """<label for="foo">theLabel</label>""" else s"""<label class="$labelExtraClasses" for="foo">theLabel</label>""")
     }
 
     "allow hide the label" in {
       val labelString = if (labelExtraClasses == "") """<label class="sr-only" for="foo">theLabel</label>""" else s"""<label class="$labelExtraClasses sr-only" for="foo">theLabel</label>"""
-      clean(simpleInputWithArgs('_label -> "theLabel", '_hideLabel -> true)) must contain(labelString)
-      clean(simpleInputWithArgs('_hiddenLabel -> "theLabel")) must contain(labelString)
+      clean(simpleInputWithArgs(Symbol("_label") -> "theLabel", Symbol("_hideLabel") -> true)) must contain(labelString)
+      clean(simpleInputWithArgs(Symbol("_hiddenLabel") -> "theLabel")) must contain(labelString)
     }
 
     "allow render without label" in {
@@ -103,7 +103,7 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "allow showing constraints" in {
-      val test = simpleInputWithArgs('_showConstraints -> true)
+      val test = simpleInputWithArgs(Symbol("_showConstraints") -> true)
       test must contain("<small id=\"foo_info_0\" class=\"form-text text-muted\">")
       test must contain("<small id=\"foo_info_1\" class=\"form-text text-muted\">")
       test must contain("class=\"form-text text-muted\">" + msgsProv.messages("constraint.required") + "</small>")
@@ -111,19 +111,19 @@ object FieldConstructorsSpec extends Specification {
     }
 
     "localize placeholder property" in {
-      val test = simpleInputWithArgs('placeholder -> "simpleInputWithArgs.placeholder.value")
+      val test = simpleInputWithArgs(Symbol("placeholder") -> "simpleInputWithArgs.placeholder.value")
       test must contain("placeholder=\"Placeholder value\"")
     }
 
     "allow showing help info" in {
-      simpleInputWithArgs('_help -> "test-help") must contain("<small id=\"foo_info_0\" class=\"form-text text-muted\">test-help</small>")
-      simpleInputWithArgs('_success -> "test-help") must contain("<div id=\"foo_feedback_0\" class=\"valid-feedback\">test-help</div>")
-      simpleInputWithArgs('_warning -> "test-help") must contain("<div id=\"foo_feedback_0\" class=\"warning-feedback\">test-help</div>")
-      simpleInputWithArgs('_error -> "test-help") must contain("<div id=\"foo_error_0\" class=\"invalid-feedback\">test-help</div>")
+      simpleInputWithArgs(Symbol("_help") -> "test-help") must contain("<small id=\"foo_info_0\" class=\"form-text text-muted\">test-help</small>")
+      simpleInputWithArgs(Symbol("_success") -> "test-help") must contain("<div id=\"foo_feedback_0\" class=\"valid-feedback\">test-help</div>")
+      simpleInputWithArgs(Symbol("_warning") -> "test-help") must contain("<div id=\"foo_feedback_0\" class=\"warning-feedback\">test-help</div>")
+      simpleInputWithArgs(Symbol("_error") -> "test-help") must contain("<div id=\"foo_error_0\" class=\"invalid-feedback\">test-help</div>")
     }
 
     "allow rendering erros and hide constraints when help info is present" in {
-      val test = simpleInputWithError('_showConstraints -> true, '_help -> "test-help")
+      val test = simpleInputWithError(Symbol("_showConstraints") -> true, Symbol("_help") -> "test-help")
       test must contain("<div id=\"foo_error_0\" class=\"invalid-feedback\">test-error-0</div>")
       test must contain("<div id=\"foo_error_1\" class=\"invalid-feedback\">test-error-1</div>")
       test must contain("<small id=\"foo_info_0\" class=\"form-text text-muted\">test-help</small>")
@@ -137,12 +137,12 @@ object FieldConstructorsSpec extends Specification {
         test must withStatus(status)
       }
 
-      testStatus("success", '_success -> true)
-      testStatus("success", '_success -> "test-help")
-      testStatus("warning", '_warning -> true)
-      testStatus("warning", '_warning -> "test-help")
-      testStatus("danger", '_error -> true)
-      testStatus("danger", '_error -> "test-help")
+      testStatus("success", Symbol("_success") -> true)
+      testStatus("success", Symbol("_success") -> "test-help")
+      testStatus("warning", Symbol("_warning") -> true)
+      testStatus("warning", Symbol("_warning") -> "test-help")
+      testStatus("danger", Symbol("_error") -> true)
+      testStatus("danger", Symbol("_error") -> "test-help")
     }
 
     "render aria attributes" in {
@@ -153,7 +153,7 @@ object FieldConstructorsSpec extends Specification {
       test0 must not contain ("<span id=\"foo_info")
       test0 must not contain ("<span id=\"foo_error")
 
-      val test1 = simpleInputWithError('_showConstraints -> true)
+      val test1 = simpleInputWithError(Symbol("_showConstraints") -> true)
       test1 must contain("aria-invalid=\"true\"")
       test1 must contain("aria-describedby=\"foo_error_0 foo_error_1 foo_info_0 foo_info_1\"")
       test1 must contain("<small id=\"foo_info_0\"")
@@ -161,28 +161,28 @@ object FieldConstructorsSpec extends Specification {
       test1 must contain("<div id=\"foo_error_0\"")
       test1 must contain("<div id=\"foo_error_1\"")
 
-      val test2 = simpleInputWithArgs('_help -> "test-help")
+      val test2 = simpleInputWithArgs(Symbol("_help") -> "test-help")
       test2 must contain("aria-describedby=\"foo_info_0\"")
       test2 must contain("<small id=\"foo_info_0\"")
       test2 must not contain ("<div id=\"foo_feedback")
     }
 
     "allow to set all its helpers as bootstrap custom fields" in {
-      val customFile1 = b4.file(fooField, '_custom -> true).body.trim
+      val customFile1 = b4.file(fooField, Symbol("_custom") -> true).body.trim
       val customFile2 = b4.file(fooField)(fcWithCustomFields, msgsProv).body.trim
       customFile1 must be equalTo customFile2
 
       val boolField = Form(single("foo" -> Forms.boolean))("foo")
-      val customCheckbox1 = b4.checkbox(boolField, '_custom -> true, '_text -> "theText").body.trim
-      val customCheckbox2 = b4.checkbox(boolField, '_text -> "theText")(fcWithCustomFields, msgsProv).body.trim
+      val customCheckbox1 = b4.checkbox(boolField, Symbol("_custom") -> true, Symbol("_text") -> "theText").body.trim
+      val customCheckbox2 = b4.checkbox(boolField, Symbol("_text") -> "theText")(fcWithCustomFields, msgsProv).body.trim
       customCheckbox1 must be equalTo customCheckbox2
 
       val fruits = Seq("A" -> "Apples", "P" -> "Pears", "B" -> "Bananas")
-      val customRadio1 = b4.radio(fooField, fruits, '_custom -> true).body.trim
+      val customRadio1 = b4.radio(fooField, fruits, Symbol("_custom") -> true).body.trim
       val customRadio2 = b4.radio(fooField, fruits)(fcWithCustomFields, msgsProv).body.trim
       customRadio1 must be equalTo customRadio2
 
-      val customSelect1 = b4.select(fooField, fruits, '_custom -> true).body.trim
+      val customSelect1 = b4.select(fooField, fruits, Symbol("_custom") -> true).body.trim
       val customSelect2 = b4.select(fooField, fruits)(fcWithCustomFields, msgsProv).body.trim
       customSelect1 must be equalTo customSelect2
     }
@@ -192,12 +192,12 @@ object FieldConstructorsSpec extends Specification {
       val test2 = simpleInputWithError()(fcWithFeedbackTooltip)
       test1.replaceAll("-feedback", "-tooltip") must be equalTo test2
 
-      val test3 = simpleInputWithArgs('_success -> "test-help")(fc)
-      val test4 = simpleInputWithArgs('_success -> "test-help")(fcWithFeedbackTooltip)
+      val test3 = simpleInputWithArgs(Symbol("_success") -> "test-help")(fc)
+      val test4 = simpleInputWithArgs(Symbol("_success") -> "test-help")(fcWithFeedbackTooltip)
       test3.replaceAll("-feedback", "-tooltip") must be equalTo test4
 
-      val test5 = simpleInputWithArgs('_warning -> "test-help")(fc)
-      val test6 = simpleInputWithArgs('_warning -> "test-help")(fcWithFeedbackTooltip)
+      val test5 = simpleInputWithArgs(Symbol("_warning") -> "test-help")(fc)
+      val test6 = simpleInputWithArgs(Symbol("_warning") -> "test-help")(fcWithFeedbackTooltip)
       test6.replaceAll("-feedback", "-tooltip") must be equalTo test6
     }
   }
@@ -211,7 +211,7 @@ object FieldConstructorsSpec extends Specification {
     testFielConstructor(horizontalFieldConstructor, fcWithCustomFields, fcWithFeedbackTooltip)
 
     "render columns for horizontal form" in {
-      val body = b4.text(Form(single("foo" -> Forms.text))("foo"), '_label -> "theLabel").body
+      val body = b4.text(Form(single("foo" -> Forms.text))("foo"), Symbol("_label") -> "theLabel").body
       body must contain(colLabel)
       body must contain(colInput)
     }

--- a/play27-bootstrap4/module/test/FormsSpec.scala
+++ b/play27-bootstrap4/module/test/FormsSpec.scala
@@ -65,12 +65,12 @@ object FormsSpec extends Specification {
     }
 
     "allow setting custom class" in {
-      fooFormBody('class -> "customClass")(vfc) must contain("class=\"form-vertical customClass\"")
+      fooFormBody(Symbol("class") -> "customClass")(vfc) must contain("class=\"form-vertical customClass\"")
     }
 
     "allow disabling default class" in {
-      fooFormBody('_disableDefaultClass -> true)(vfc) must not contain ("form-vertical")
-      fooFormBody('_disableDefaultClass -> true, 'class -> "customClass")(vfc) must contain("class=\"customClass\"")
+      fooFormBody(Symbol("_disableDefaultClass") -> true)(vfc) must not contain ("form-vertical")
+      fooFormBody(Symbol("_disableDefaultClass") -> true, Symbol("class") -> "customClass")(vfc) must contain("class=\"customClass\"")
     }
 
     "add form role as default" in {
@@ -78,7 +78,7 @@ object FormsSpec extends Specification {
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = fooFormBody('extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test")(vfc)
+      val body = fooFormBody(Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test")(vfc)
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")

--- a/play27-bootstrap4/module/test/HelpersSpec.scala
+++ b/play27-bootstrap4/module/test/HelpersSpec.scala
@@ -60,7 +60,7 @@ object HelpersSpec extends Specification {
   "@inputType" should {
 
     "allow setting a custom id" in {
-      val body = b4.inputType("text", fooField, 'id -> "someid").body
+      val body = b4.inputType("text", fooField, Symbol("id") -> "someid").body
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
       // Make sure it doesn't have it twice
@@ -80,11 +80,11 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b4.inputType("text", fooField, 'class -> "extra_class").body must contain("class=\"form-control extra_class\"")
+      b4.inputType("text", fooField, Symbol("class") -> "extra_class").body must contain("class=\"form-control extra_class\"")
     }
 
     "allow setting a default value" in {
-      val body = b4.inputType("text", fooField, 'value -> "defaultvalue").body
+      val body = b4.inputType("text", fooField, Symbol("value") -> "defaultvalue").body
       val valueAttr = "value=\"defaultvalue\""
       body must contain(valueAttr)
       // Make sure it doesn't contain it twice
@@ -92,7 +92,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow being filled with a value" in {
-      val body = b4.inputType("text", fooFieldFilled("filledvalue"), 'value -> "defaultvalue").body
+      val body = b4.inputType("text", fooFieldFilled("filledvalue"), Symbol("value") -> "defaultvalue").body
       val valueAttr = "value=\"filledvalue\""
       body must contain(valueAttr)
       // Make sure it doesn't contain it twice
@@ -102,7 +102,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = b4.inputType("text", fooField, 'extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test").body
+      val body = b4.inputType("text", fooField, Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test").body
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")
@@ -110,7 +110,7 @@ object HelpersSpec extends Specification {
     }
   }
 
-  val sampleArgs = Seq[(Symbol, Any)]('id -> "someid", 'foo -> "fooValue")
+  val sampleArgs = Seq[(Symbol, Any)](Symbol("id") -> "someid", Symbol("foo") -> "fooValue")
   def sampleInputTypeBody(theType: String) = b4.inputType(theType, fooField, sampleArgs: _*).body.trim
 
   "@text" should {
@@ -134,7 +134,7 @@ object HelpersSpec extends Specification {
       file must contain("""foo="fooValue"""")
     }
     "render custom file properly" in {
-      val customFile = b4.file(fooField, (('_custom -> true) +: sampleArgs): _*).body.trim
+      val customFile = b4.file(fooField, ((Symbol("_custom") -> true) +: sampleArgs): _*).body.trim
       customFile must contain("""<div class="custom-file">""")
       customFile must contain("""<input type="file" id="someid" name="foo" value=""""")
       customFile must contain("""class="custom-file-input"""")
@@ -146,7 +146,7 @@ object HelpersSpec extends Specification {
   "@textarea" should {
 
     "allow setting a custom id" in {
-      val body = b4.textarea(fooField, 'id -> "someid").body
+      val body = b4.textarea(fooField, Symbol("id") -> "someid").body
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
       // Make sure it doesn't have it twice
@@ -158,11 +158,11 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b4.textarea(fooField, 'class -> "extra_class").body must contain("class=\"form-control extra_class\"")
+      b4.textarea(fooField, Symbol("class") -> "extra_class").body must contain("class=\"form-control extra_class\"")
     }
 
     "allow setting a default value" in {
-      val body = b4.textarea(fooField, 'value -> "defaultvalue").body
+      val body = b4.textarea(fooField, Symbol("value") -> "defaultvalue").body
       body must contain(">defaultvalue</textarea>")
       body must not contain ("value=\"defaultvalue\"")
     }
@@ -175,7 +175,7 @@ object HelpersSpec extends Specification {
     def stringFieldFilled(v: String) = Form(single("foo" -> Forms.text)).fill(v)("foo")
 
     "allow setting a custom id" in {
-      val body = b4.checkbox(boolField, 'id -> "someid").body
+      val body = b4.checkbox(boolField, Symbol("id") -> "someid").body
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
       // Make sure it doesn't have it twice
@@ -189,19 +189,19 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting a default custom value" in {
-      val body = b4.checkbox(boolField, 'value -> "bar").body
+      val body = b4.checkbox(boolField, Symbol("value") -> "bar").body
       body must not contain ("checked")
       body must contain("value=\"bar\"")
     }
 
     "allow setting a default value for checked attribute" in {
-      val body = b4.checkbox(boolField, '_default -> true).body
+      val body = b4.checkbox(boolField, Symbol("_default") -> true).body
       body must contain("checked")
       body must contain("value=\"true\"")
     }
 
     "allow setting a default value for checked attribute with a custom value" in {
-      val body = b4.checkbox(boolField, 'value -> "bar", '_default -> true).body
+      val body = b4.checkbox(boolField, Symbol("value") -> "bar", Symbol("_default") -> true).body
       body must contain("checked")
       body must contain("value=\"bar\"")
     }
@@ -213,66 +213,66 @@ object HelpersSpec extends Specification {
     }
 
     "allow being filled with a custom value" in {
-      val body = b4.checkbox(stringFieldFilled("bar"), 'value -> "bar").body
+      val body = b4.checkbox(stringFieldFilled("bar"), Symbol("value") -> "bar").body
       body must contain("checked")
       body must contain("value=\"bar\"")
     }
 
     "ignore default checked value if it is filled" in {
-      val body1 = b4.checkbox(boolFieldFilled(false), '_default -> true).body
+      val body1 = b4.checkbox(boolFieldFilled(false), Symbol("_default") -> true).body
       body1 must not contain ("checked")
       body1 must contain("value=\"true\"")
-      val body2 = b4.checkbox(stringFieldFilled(""), 'value -> "bar", '_default -> true).body
+      val body2 = b4.checkbox(stringFieldFilled(""), Symbol("value") -> "bar", Symbol("_default") -> true).body
       body2 must not contain ("checked")
       body2 must contain("value=\"bar\"")
     }
 
     "allow setting a forced value for checked attribute (always true)" in {
-      val body = b4.checkbox(boolField, 'checked -> true).body
+      val body = b4.checkbox(boolField, Symbol("checked") -> true).body
       body must contain("checked")
       body must contain("value=\"true\"")
     }
     "allow setting a forced value for checked attribute (always false)" in {
-      val body = b4.checkbox(boolField, 'checked -> false).body
+      val body = b4.checkbox(boolField, Symbol("checked") -> false).body
       body must not contain ("checked")
       body must contain("value=\"true\"")
     }
 
     "ignore default and filled checked value if it has forced checked" in {
-      val body1 = b4.checkbox(boolFieldFilled(false), '_default -> false, 'checked -> true).body
+      val body1 = b4.checkbox(boolFieldFilled(false), Symbol("_default") -> false, Symbol("checked") -> true).body
       body1 must contain("checked")
       body1 must contain("value=\"true\"")
-      val body2 = b4.checkbox(boolFieldFilled(true), '_default -> true, 'checked -> false).body
+      val body2 = b4.checkbox(boolFieldFilled(true), Symbol("_default") -> true, Symbol("checked") -> false).body
       body2 must not contain ("checked")
       body2 must contain("value=\"true\"")
-      val body3 = b4.checkbox(stringFieldFilled(""), 'value -> "bar", '_default -> false, 'checked -> true).body
+      val body3 = b4.checkbox(stringFieldFilled(""), Symbol("value") -> "bar", Symbol("_default") -> false, Symbol("checked") -> true).body
       body3 must contain("checked")
       body3 must contain("value=\"bar\"")
-      val body4 = b4.checkbox(stringFieldFilled("bar"), 'value -> "bar", '_default -> true, 'checked -> false).body
+      val body4 = b4.checkbox(stringFieldFilled("bar"), Symbol("value") -> "bar", Symbol("_default") -> true, Symbol("checked") -> false).body
       body4 must not contain ("checked")
       body4 must contain("value=\"bar\"")
     }
 
     "add support to readonly attribute" in {
-      val bodyWithoutReadonly = b4.checkbox(boolField, 'value -> true).body
+      val bodyWithoutReadonly = b4.checkbox(boolField, Symbol("value") -> true).body
       bodyWithoutReadonly must contain("<div class=\"form-check")
       bodyWithoutReadonly must not contain ("checkbox-group")
       bodyWithoutReadonly must not contain ("disabled")
       bodyWithoutReadonly must not contain ("<input type=\"hidden\"")
 
-      val bodyReadonlyFalse = b4.checkbox(boolField, 'readonly -> false, 'value -> true).body
+      val bodyReadonlyFalse = b4.checkbox(boolField, Symbol("readonly") -> false, Symbol("value") -> true).body
       bodyReadonlyFalse must contain("<div class=\"form-check checkbox-group")
       bodyReadonlyFalse must not contain ("disabled=\"true\"")
       bodyReadonlyFalse must contain("<input type=\"hidden\" name=\"foo\" value=\"true\" disabled/>")
 
-      val bodyReadonlyTrue = b4.checkbox(boolField, 'readonly -> true, 'value -> true).body
+      val bodyReadonlyTrue = b4.checkbox(boolField, Symbol("readonly") -> true, Symbol("value") -> true).body
       bodyReadonlyTrue must contain("<div class=\"form-check checkbox-group")
       bodyReadonlyTrue must contain("disabled=\"true\"")
       bodyReadonlyTrue must contain("<input type=\"hidden\" name=\"foo\" value=\"true\"/>")
     }
 
     "render custom checkbox properly" in {
-      val body = clean(b4.checkbox(boolField, '_custom -> true, '_text -> "theText").body)
+      val body = clean(b4.checkbox(boolField, Symbol("_custom") -> true, Symbol("_text") -> "theText").body)
       body must contain("""<div class="custom-control custom-checkbox">""")
       body must contain("""<input type="checkbox" id="foo" name="foo" value="true" class="custom-control-input">""")
       body must contain("""<label class="custom-control-label" for="foo">theText</label>""")
@@ -284,7 +284,7 @@ object HelpersSpec extends Specification {
     val fruits = Seq("A" -> "Apples", "P" -> "Pears", "B" -> "Bananas")
 
     "allow setting a custom id" in {
-      val body = b4.radio(fooField, fruits, 'id -> "someid").body
+      val body = b4.radio(fooField, fruits, Symbol("id") -> "someid").body
       body must contain("id=\"someid_A\"")
       body must contain("id=\"someid_P\"")
       body must contain("id=\"someid_B\"")
@@ -295,7 +295,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting a default value" in {
-      val body = b4.radio(fooField, fruits, 'value -> "B").body
+      val body = b4.radio(fooField, fruits, Symbol("value") -> "B").body
       val checkedAttr = "checked"
       body must contain(checkedAttr)
       // Make sure it doesn't have it twice
@@ -315,22 +315,22 @@ object HelpersSpec extends Specification {
     }
 
     "allow be inline" in {
-      b4.radio(fooField, fruits, '_inline -> true).body must contain("form-check-inline")
+      b4.radio(fooField, fruits, Symbol("_inline") -> true).body must contain("form-check-inline")
     }
 
     "add support to readonly attribute" in {
-      val bodyWithoutReadonly = b4.radio(fooField, fruits, 'value -> "B").body
+      val bodyWithoutReadonly = b4.radio(fooField, fruits, Symbol("value") -> "B").body
       bodyWithoutReadonly must not contain ("radio-group")
       bodyWithoutReadonly must not contain ("disabled")
       bodyWithoutReadonly must not contain ("<input type=\"hidden\"")
 
-      val bodyReadonlyFalse = b4.radio(fooField, fruits, 'readonly -> false, 'value -> "B").body
+      val bodyReadonlyFalse = b4.radio(fooField, fruits, Symbol("readonly") -> false, Symbol("value") -> "B").body
       bodyReadonlyFalse must contain("<div class=\"radio-group\">")
       bodyReadonlyFalse must not contain ("disabled=\"true\"")
       bodyReadonlyFalse must contain("<div class=\"form-check")
       bodyReadonlyFalse must contain("<input type=\"hidden\" name=\"foo\" value=\"B\" disabled/>")
 
-      val bodyReadonlyTrue = b4.radio(fooField, fruits, 'readonly -> true, 'value -> "B").body
+      val bodyReadonlyTrue = b4.radio(fooField, fruits, Symbol("readonly") -> true, Symbol("value") -> "B").body
       bodyReadonlyTrue must contain("<div class=\"radio-group\">")
       bodyReadonlyTrue must contain("disabled=\"true\"")
       bodyReadonlyTrue must contain("<div class=\"form-check\"")
@@ -338,7 +338,7 @@ object HelpersSpec extends Specification {
     }
 
     "render custom radio properly" in {
-      val body = clean(b4.radio(fooField, fruits, '_custom -> true).body)
+      val body = clean(b4.radio(fooField, fruits, Symbol("_custom") -> true).body)
       body must contain("""<div class="custom-control custom-radio">""")
       body must contain("""<input type="radio" id="foo_""")
       body must contain("""class="custom-control-input"""")
@@ -351,7 +351,7 @@ object HelpersSpec extends Specification {
     val fruits = Seq("A" -> "Apples", "P" -> "Pears", "B" -> "Bananas")
 
     "allow setting a custom id" in {
-      val body = b4.select(fooField, fruits, 'id -> "someid").body
+      val body = b4.select(fooField, fruits, Symbol("id") -> "someid").body
       body must contain("id=\"someid\"")
     }
 
@@ -360,7 +360,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b4.select(fooField, fruits, 'class -> "extra_class").body must contain("class=\"form-control extra_class\"")
+      b4.select(fooField, fruits, Symbol("class") -> "extra_class").body must contain("class=\"form-control extra_class\"")
     }
 
     "be unselected by default" in {
@@ -368,7 +368,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting a default value" in {
-      val body = b4.select(fooField, fruits, 'value -> "B").body
+      val body = b4.select(fooField, fruits, Symbol("value") -> "B").body
       val selectedAttr = "selected"
       body must contain(selectedAttr)
       // Make sure it doesn't have it twice
@@ -384,24 +384,24 @@ object HelpersSpec extends Specification {
     }
 
     "add support to readonly attribute" in {
-      val bodyWithoutReadonly = b4.select(fooField, fruits, 'value -> "B").body
+      val bodyWithoutReadonly = b4.select(fooField, fruits, Symbol("value") -> "B").body
       bodyWithoutReadonly must not contain ("<div class=\"select-group\">")
       bodyWithoutReadonly must not contain ("disabled")
       bodyWithoutReadonly must not contain ("<input type=\"hidden\"")
 
-      val bodyReadonlyFalse = b4.select(fooField, fruits, 'readonly -> false, 'value -> "B").body
+      val bodyReadonlyFalse = b4.select(fooField, fruits, Symbol("readonly") -> false, Symbol("value") -> "B").body
       bodyReadonlyFalse must contain("<div class=\"select-group\">")
       bodyReadonlyFalse must not contain ("disabled=\"true\"")
       bodyReadonlyFalse must contain("<input type=\"hidden\" name=\"foo\" value=\"B\" disabled/>")
 
-      val bodyReadonlyTrue = b4.select(fooField, fruits, 'readonly -> true, 'value -> "B").body
+      val bodyReadonlyTrue = b4.select(fooField, fruits, Symbol("readonly") -> true, Symbol("value") -> "B").body
       bodyReadonlyTrue must contain("<div class=\"select-group\">")
       bodyReadonlyTrue must contain("disabled=\"true\"")
       bodyReadonlyTrue must contain("<input type=\"hidden\" name=\"foo\" value=\"B\"/>")
     }
 
     "allow multiple" in {
-      val body = b4.select(fooField, fruits, 'multiple -> true, 'value -> "P,B").body
+      val body = b4.select(fooField, fruits, Symbol("multiple") -> true, Symbol("value") -> "P,B").body
       body must contain("multiple=\"true\"")
       val selectedAttr = "selected"
       body must contain(selectedAttr)
@@ -412,22 +412,22 @@ object HelpersSpec extends Specification {
     }
 
     "render custom select properly" in {
-      val body = b4.select(fooField, fruits, '_custom -> true).body
+      val body = b4.select(fooField, fruits, Symbol("_custom") -> true).body
       body must contain("""<select id="foo" name="foo" class="custom-select">""")
     }
   }
 
   "@hidden" should {
     "be rendered correctly" in {
-      val body = clean(b4.hidden("testName", "testValue", 'foo -> "bar").body)
+      val body = clean(b4.hidden("testName", "testValue", Symbol("foo") -> "bar").body)
       body must be equalTo """<input type="hidden" name="testName" value="testValue" foo="bar">"""
     }
     "with Field object" in {
-      val body = clean(b4.hidden(fooField, 'value -> "testValue", 'foo -> "bar").body)
+      val body = clean(b4.hidden(fooField, Symbol("value") -> "testValue", Symbol("foo") -> "bar").body)
       body must be equalTo """<input type="hidden" name="foo" value="testValue" foo="bar">"""
     }
     "with filled Field object" in {
-      val body = clean(b4.hidden(fooFieldFilled("filledValue"), 'value -> "testValue", 'foo -> "bar").body)
+      val body = clean(b4.hidden(fooFieldFilled("filledValue"), Symbol("value") -> "testValue", Symbol("foo") -> "bar").body)
       body must be equalTo """<input type="hidden" name="foo" value="filledValue" foo="bar">"""
     }
   }
@@ -510,7 +510,7 @@ object HelpersSpec extends Specification {
       clean(b4.freeFormGroup(args)(innerArgs => Html("<content>"))(fc, msgsProv).body)
 
     "vertical: show label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(vfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId", Symbol("_label") -> "theLabel")(vfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<label>theLabel</label>
 	  	<content>
@@ -518,14 +518,14 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "vertical: without label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId")(vfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId")(vfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<content>
 	  </div>
 	  """)
     }
     "horizontal: show label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(hfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId", Symbol("_label") -> "theLabel")(hfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group row theClass" id="theId">
 	  	<label class="col-form-label col-md-2">theLabel</label>
 	  	<div class="col-md-10">
@@ -535,7 +535,7 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "horizontal: without label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId")(hfc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId")(hfc, msgsProv) must be equalTo clean("""
 	  <div class="form-group row theClass" id="theId">
 	  	<div class="col-md-10 offset-md-2">
 	  	  <content>
@@ -544,7 +544,7 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "inline: show label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId", '_label -> "theLabel")(ifc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId", Symbol("_label") -> "theLabel")(ifc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
 	  	<label>theLabel</label>
       <content>
@@ -552,7 +552,7 @@ object HelpersSpec extends Specification {
 	  """)
     }
     "inline: without label" in {
-      testFormGroup('_class -> "theClass", '_id -> "theId")(ifc, msgsProv) must be equalTo clean("""
+      testFormGroup(Symbol("_class") -> "theClass", Symbol("_id") -> "theId")(ifc, msgsProv) must be equalTo clean("""
 	  <div class="form-group theClass" id="theId">
       <content>
 	  </div>
@@ -560,7 +560,7 @@ object HelpersSpec extends Specification {
     }
 
     "get the inner arguments for the content" in {
-      val body = b4.freeFormGroup(Seq('_class -> "theClass", '_underscored -> "underscored", 'foo -> "foo"))(innerArgsMap => Html(innerArgsMap.toSeq.map(a => s"""${a._1.name}="${a._2.toString}"""").mkString("<content ", " ", ">")))(vfc, msgsProv).body
+      val body = b4.freeFormGroup(Seq(Symbol("_class") -> "theClass", Symbol("_underscored") -> "underscored", Symbol("foo") -> "foo"))(innerArgsMap => Html(innerArgsMap.toSeq.map(a => s"""${a._1.name}="${a._2.toString}"""").mkString("<content ", " ", ">")))(vfc, msgsProv).body
       body must not contain "_class=\"theClass\""
       body must not contain "_underscored=\"underscored\""
       body must contain("foo=\"foo\"")
@@ -569,7 +569,7 @@ object HelpersSpec extends Specification {
 
   "@free" should {
     "be rendered correctly" in {
-      clean(b4.free('foo -> "fooValue")(Html("<content>"))(vfc, msgsProv).body) must be equalTo clean(b4.freeFormGroup(Seq('foo -> "fooValue"))(_ => Html("<content>"))(vfc, msgsProv).body)
+      clean(b4.free(Symbol("foo") -> "fooValue")(Html("<content>"))(vfc, msgsProv).body) must be equalTo clean(b4.freeFormGroup(Seq(Symbol("foo") -> "fooValue"))(_ => Html("<content>"))(vfc, msgsProv).body)
     }
   }
 
@@ -580,11 +580,11 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting additional classes" in {
-      b4.static("theLabel", 'class -> "extra_class")(Html("theText"))(vfc, msgsProv).body must contain("<p class=\"form-control-static extra_class\">theText</p>")
+      b4.static("theLabel", Symbol("class") -> "extra_class")(Html("theText"))(vfc, msgsProv).body must contain("<p class=\"form-control-static extra_class\">theText</p>")
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = b4.static("theLabel", 'extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test")(Html("theText"))(vfc, msgsProv).body
+      val body = b4.static("theLabel", Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test")(Html("theText"))(vfc, msgsProv).body
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")
@@ -610,7 +610,7 @@ object HelpersSpec extends Specification {
     }
 
     "allow setting extra arguments and remove those arguments with false values or with underscored names" in {
-      val body = buttonTypeBody('extra_attr -> "test", 'true_attr -> true, 'fase_attr -> false, '_underscored_attr -> "test")
+      val body = buttonTypeBody(Symbol("extra_attr") -> "test", Symbol("true_attr") -> true, Symbol("fase_attr") -> false, Symbol("_underscored_attr") -> "test")
       body must contain("extra_attr=\"test\"")
       body must contain("true_attr=\"true\"")
       body must not contain ("false_attr=\"false\"")
@@ -618,7 +618,7 @@ object HelpersSpec extends Specification {
     }
 
     "be rendered correctly" in {
-      val body = buttonTypeBody('id -> "someid", 'class -> "btn btn-default")
+      val body = buttonTypeBody(Symbol("id") -> "someid", Symbol("class") -> "btn btn-default")
       body must contain("<button type=\"" + sampleType + "\" id=\"someid\" class=\"btn btn-default\">" + sampleContent + "</button>")
     }
   }
@@ -644,16 +644,16 @@ object HelpersSpec extends Specification {
   "@inputWrapped" should {
 
     "be equivalent to inputType for an empty wrapper" in {
-      val bodyInputType = clean(b4.inputType("text", fooField, 'id -> "someid").body)
-      val body = clean(b4.inputWrapped("text", fooField, 'id -> "someid")(x => x).body)
+      val bodyInputType = clean(b4.inputType("text", fooField, Symbol("id") -> "someid").body)
+      val body = clean(b4.inputWrapped("text", fooField, Symbol("id") -> "someid")(x => x).body)
       body must be equalTo bodyInputType
     }
 
     "wrap the input" in {
-      val bodyInputType = clean(b4.inputType("text", fooField, 'id -> "someid").body)
+      val bodyInputType = clean(b4.inputType("text", fooField, Symbol("id") -> "someid").body)
       val (wrapperPre, wrapperPost) = ("<wrapper>", "</wrapper>")
       def wrap(input: Html) = HtmlFormat.fill(scala.collection.immutable.Seq(Html(wrapperPre), input, Html(wrapperPost)))
-      val body = clean(b4.inputWrapped("text", fooField, 'id -> "someid")(input => wrap(input)).body)
+      val body = clean(b4.inputWrapped("text", fooField, Symbol("id") -> "someid")(input => wrap(input)).body)
 
       val (indexOfWrapperPre, indexOfWrapperPost) = (body.indexOf(wrapperPre), body.indexOf(wrapperPost))
 
@@ -677,7 +677,7 @@ object HelpersSpec extends Specification {
     def fooMultifieldWithFielsArgs(fieldsArgs: (Symbol, Any)*) = multifield(fooForm, fieldsArgs = fieldsArgs)(vfc, msgsProv)
 
     "have the basic structure" in {
-      val body = fooMultifield('_label -> "theLabel")
+      val body = fooMultifield(Symbol("_label") -> "theLabel")
       body must contain("class=\"form-group")
       body must not contain ("has-danger")
       body must contain("<label>theLabel</label>")
@@ -687,22 +687,22 @@ object HelpersSpec extends Specification {
     }
 
     "behave as a horizontal field constructor" in {
-      val body = multifield(fooForm, Seq('_label -> "theLabel"))(hfc, msgsProv)
+      val body = multifield(fooForm, Seq(Symbol("_label") -> "theLabel"))(hfc, msgsProv)
       body must contain("<label class=\"col-form-label " + colLabel + "\">theLabel</label>")
       body must contain("<div class=\"" + colInput + "\">")
     }
 
     "allow setting a custom id" in {
-      fooMultifield('_id -> "customid") must contain("id=\"customid\"")
+      fooMultifield(Symbol("_id") -> "customid") must contain("id=\"customid\"")
     }
 
     "allow setting extra classes form-group" in {
-      fooMultifield('_class -> "extra_class another_class") must contain("class=\"form-group extra_class another_class")
+      fooMultifield(Symbol("_class") -> "extra_class another_class") must contain("class=\"form-group extra_class another_class")
     }
 
     "show label" in {
-      multifield(fooForm, Seq('_label -> "fooLabel"))(vfc, msgsProv) must contain("<label>fooLabel</label>")
-      multifield(fooForm, Seq('_label -> "fooLabel"))(hfc, msgsProv) must contain("<label class=\"col-form-label " + colLabel + "\">fooLabel</label>")
+      multifield(fooForm, Seq(Symbol("_label") -> "fooLabel"))(vfc, msgsProv) must contain("<label>fooLabel</label>")
+      multifield(fooForm, Seq(Symbol("_label") -> "fooLabel"))(hfc, msgsProv) must contain("<label class=\"col-form-label " + colLabel + "\">fooLabel</label>")
     }
 
     "without label" in {
@@ -717,17 +717,17 @@ object HelpersSpec extends Specification {
     }
 
     "allow showing constraints" in {
-      fooMultifield('_showConstraints -> true) must contain("<small class=\"form-text text-muted\">" + msgsProv.messages("constraint.required") + "</small>")
+      fooMultifield(Symbol("_showConstraints") -> true) must contain("<small class=\"form-text text-muted\">" + msgsProv.messages("constraint.required") + "</small>")
     }
 
     "allow showing help info" in {
-      fooMultifield('_help -> "test-help") must contain("""<small class="form-text text-muted">test-help</small>""")
-      fooMultifield('_success -> "test-help") must contain("""<div class="valid-feedback">test-help</div>""")
-      fooMultifieldWithFielsArgs('_success -> "test-help") must contain("""<div class="valid-feedback">test-help</div>""")
-      fooMultifield('_warning -> "test-help") must contain("""<div class="warning-feedback">test-help</div>""")
-      fooMultifieldWithFielsArgs('_warning -> "test-help") must contain("""<div class="warning-feedback">test-help</div>""")
-      fooMultifield('_error -> "test-help") must contain("""<div class="invalid-feedback">test-help</div>""")
-      fooMultifieldWithFielsArgs('_error -> "test-help") must contain("""<div class="invalid-feedback">test-help</div>""")
+      fooMultifield(Symbol("_help") -> "test-help") must contain("""<small class="form-text text-muted">test-help</small>""")
+      fooMultifield(Symbol("_success") -> "test-help") must contain("""<div class="valid-feedback">test-help</div>""")
+      fooMultifieldWithFielsArgs(Symbol("_success") -> "test-help") must contain("""<div class="valid-feedback">test-help</div>""")
+      fooMultifield(Symbol("_warning") -> "test-help") must contain("""<div class="warning-feedback">test-help</div>""")
+      fooMultifieldWithFielsArgs(Symbol("_warning") -> "test-help") must contain("""<div class="warning-feedback">test-help</div>""")
+      fooMultifield(Symbol("_error") -> "test-help") must contain("""<div class="invalid-feedback">test-help</div>""")
+      fooMultifieldWithFielsArgs(Symbol("_error") -> "test-help") must contain("""<div class="invalid-feedback">test-help</div>""")
     }
 
     "render validation states" in {
@@ -740,18 +740,18 @@ object HelpersSpec extends Specification {
         test must withStatus(status)
       }
 
-      testStatus("success", withFieldsArgs = false, '_success -> true)
-      testStatus("success", withFieldsArgs = true, '_success -> true)
-      testStatus("success", withFieldsArgs = false, '_success -> "test-help")
-      testStatus("success", withFieldsArgs = true, '_success -> "test-help")
-      testStatus("warning", withFieldsArgs = false, '_warning -> true)
-      testStatus("warning", withFieldsArgs = true, '_warning -> true)
-      testStatus("warning", withFieldsArgs = false, '_warning -> "test-help")
-      testStatus("warning", withFieldsArgs = true, '_warning -> "test-help")
-      testStatus("danger", withFieldsArgs = false, '_error -> true)
-      testStatus("danger", withFieldsArgs = true, '_error -> true)
-      testStatus("danger", withFieldsArgs = false, '_error -> "test-help")
-      testStatus("danger", withFieldsArgs = true, '_error -> "test-help")
+      testStatus("success", withFieldsArgs = false, Symbol("_success") -> true)
+      testStatus("success", withFieldsArgs = true, Symbol("_success") -> true)
+      testStatus("success", withFieldsArgs = false, Symbol("_success") -> "test-help")
+      testStatus("success", withFieldsArgs = true, Symbol("_success") -> "test-help")
+      testStatus("warning", withFieldsArgs = false, Symbol("_warning") -> true)
+      testStatus("warning", withFieldsArgs = true, Symbol("_warning") -> true)
+      testStatus("warning", withFieldsArgs = false, Symbol("_warning") -> "test-help")
+      testStatus("warning", withFieldsArgs = true, Symbol("_warning") -> "test-help")
+      testStatus("danger", withFieldsArgs = false, Symbol("_error") -> true)
+      testStatus("danger", withFieldsArgs = true, Symbol("_error") -> true)
+      testStatus("danger", withFieldsArgs = false, Symbol("_error") -> "test-help")
+      testStatus("danger", withFieldsArgs = true, Symbol("_error") -> "test-help")
     }
 
   }

--- a/play27-bootstrap4/sample/app/views/b4/my/email.scala.html
+++ b/play27-bootstrap4/sample/app/views/b4/my/email.scala.html
@@ -1,5 +1,5 @@
 @(field: Field, args: (Symbol,Any)*)(implicit handler: b4.B4FieldConstructor, msgsProv: MessagesProvider)
-@b4.inputFormGroup(field, withLabelFor = true, bs.Args.withDefault(args, 'class -> "form-control")) { fieldInfo =>
+@b4.inputFormGroup(field, withLabelFor = true, bs.Args.withDefault(args, Symbol("class") -> "form-control")) { fieldInfo =>
 	<div class="input-group">
 		<div class="input-group-prepend">
 			<span class="input-group-text">@@</span>

--- a/play27-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
+++ b/play27-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
@@ -2,7 +2,7 @@
 @alertStatus = @{
 	if (fieldInfo.hasErrors)
 		"alert-danger"
-	else if (bs.ArgsMap.isTrue(fieldInfo.argsMap, '_success))
+	else if (bs.ArgsMap.isTrue(fieldInfo.argsMap, Symbol("_success")))
 		"alert-success"
 	else
 		"alert-info"

--- a/play27-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
+++ b/play27-bootstrap4/sample/app/views/b4/my/vertical/bsFieldConstructor.scala.html
@@ -7,7 +7,7 @@
 	else
 		"alert-info"
 }
-<div class="my-form-group form-group @fieldInfo.argsMap.get('_class) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
+<div class="my-form-group form-group @fieldInfo.argsMap.get(Symbol("_class")) @fieldInfo.status.map("has-"+_)" id="@fieldInfo.idFormField">
 	<div class="field-container">
 		@fieldInfo.labelOpt.map { label =>
 			<label@if(fieldInfo.hideLabel){ class="sr-only"} @if(fieldInfo.withLabelFor){for="@fieldInfo.id"}>@bs.Args.msg(label)(msgsProv)</label>

--- a/play27-bootstrap4/sample/app/views/b4/my/vertical/bsFormGroup.scala.html
+++ b/play27-bootstrap4/sample/app/views/b4/my/vertical/bsFormGroup.scala.html
@@ -1,14 +1,14 @@
 @(contentHtml: Html, argsMap: Map[Symbol, Any])(implicit msgsProv: MessagesProvider)
-<div class="my-form-group form-group @argsMap.get('_class)" id="@argsMap.get('_id)">
+<div class="my-form-group form-group @argsMap.get(Symbol("_class"))" id="@argsMap.get(Symbol("_id"))">
 	<div class="field-container">
-		@argsMap.get('_label).map { label =>
+		@argsMap.get(Symbol("_label")).map { label =>
 			<label>@bs.Args.msg(label)(msgsProv)</label>
 		}
 		@contentHtml
 	</div>
 	<div class="alert alert-info" role="alert">
 		<ul>
-			@argsMap.get('_help).map { help =>
+			@argsMap.get(Symbol("_help")).map { help =>
 				<li><span class="help-info"><i class="fa fa-warning-sign"> @bs.Args.msg(help)(msgsProv)</i></li>
 			}
 		</ul>

--- a/play27-bootstrap4/sample/app/views/docs.scala.html
+++ b/play27-bootstrap4/sample/app/views/docs.scala.html
@@ -38,9 +38,9 @@
 
 			<h3 id="arguments">Arguments (<code>args</code>)</h3>
 			@bsExampleWithCode {
-				@b4.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			}{
-				@@b4.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@@b4.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			}
 
 			<h4 id="arguments-special">Special arguments (the underscored ones)</h4>
@@ -48,16 +48,16 @@
 			<h4 id="arguments-validation">Validation arguments</h4>
 			@bsExampleWithCode {
         <div class="example-html5-validation">
-          @b4.text( validationForm("username"), '_label -> "Username", '_help -> "A username between 1 and 20 characters" )
-          @b4.email( validationForm("email"), '_label -> "Email" )
-          @b4.number( validationForm("age"), '_label -> "Age", '_help -> "From 18 to 99 years old" )
-          @b4.text( validationForm("color"), '_label -> "Hexadecimal color", '_help -> "Format is #CCC or #CCCCCC" )
+          @b4.text( validationForm("username"), Symbol("_label") -> "Username", Symbol("_help") -> "A username between 1 and 20 characters" )
+          @b4.email( validationForm("email"), Symbol("_label") -> "Email" )
+          @b4.number( validationForm("age"), Symbol("_label") -> "Age", Symbol("_help") -> "From 18 to 99 years old" )
+          @b4.text( validationForm("color"), Symbol("_label") -> "Hexadecimal color", Symbol("_help") -> "Format is #CCC or #CCCCCC" )
         </div>
 			}{
-				@@b4.text( validationForm("username"), '_label -> "Username", '_help -> "A username between 1 and 20 characters" )
-				@@b4.email( validationForm("email"), '_label -> "Email" )
-				@@b4.number( validationForm("age"), '_label -> "Age", '_help -> "From 18 to 99 years old" )
-				@@b4.text( validationForm("color"), '_label -> "Hexadecimal color", '_help -> "Format is #CCC or #CCCCCC" )
+				@@b4.text( validationForm("username"), Symbol("_label") -> "Username", Symbol("_help") -> "A username between 1 and 20 characters" )
+				@@b4.email( validationForm("email"), Symbol("_label") -> "Email" )
+				@@b4.number( validationForm("age"), Symbol("_label") -> "Age", Symbol("_help") -> "From 18 to 99 years old" )
+				@@b4.text( validationForm("color"), Symbol("_label") -> "Hexadecimal color", Symbol("_help") -> "Format is #CCC or #CCCCCC" )
 			}
 
 			<h4 id="arguments-optional">Optional arguments</h4>
@@ -78,25 +78,25 @@
 			<h4 id="helpers-disabled-readonly">About <code>disabled</code> and <code>readonly</code> attributes</h4>
 			<h4 id="helpers-validation-states">Validation states & feedback tooltips</h4>
 			@bsExampleWithCode {
-				@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", '_help -> "A help text", 'placeholder -> "Success text..." )
-				@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_help -> "A help text", 'placeholder -> "Warning text..." )
-				@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "A help text", 'placeholder -> "Error text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Success text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Warning text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Error text..." )
 			}{
-				@@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", '_help -> "A help text", 'placeholder -> "Success text..." )
-				@@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_help -> "A help text", 'placeholder -> "Warning text..." )
-				@@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "A help text", 'placeholder -> "Error text..." )
+				@@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Success text..." )
+				@@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Warning text..." )
+				@@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Error text..." )
 			}
 			@bsExampleWithCode {
-				@b4.vertical.form(routes.Application.vertical, '_feedbackTooltip -> true) { implicit vfc =>
-					@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", '_help -> "A help text", 'placeholder -> "Success text...", '_class -> "position-relative" )
-					@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_help -> "A help text", 'placeholder -> "Warning text...", '_class -> "position-relative" )
-					@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "A help text", 'placeholder -> "Error text...", '_class -> "position-relative" )
+				@b4.vertical.form(routes.Application.vertical, Symbol("_feedbackTooltip") -> true) { implicit vfc =>
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Success text...", Symbol("_class") -> "position-relative" )
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Warning text...", Symbol("_class") -> "position-relative" )
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Error text...", Symbol("_class") -> "position-relative" )
 				}
 			}{
-				@@b4.vertical.form(routes.Application.vertical, '_feedbackTooltip -> true) { implicit vfc =>
-					@@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", '_help -> "A help text", 'placeholder -> "Success text...", '_class -> "position-relative" )
-					@@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", '_help -> "A help text", 'placeholder -> "Warning text...", '_class -> "position-relative" )
-					@@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "A help text", 'placeholder -> "Error text...", '_class -> "position-relative" )
+				@@b4.vertical.form(routes.Application.vertical, Symbol("_feedbackTooltip") -> true) { implicit vfc =>
+					@@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Success text...", Symbol("_class") -> "position-relative" )
+					@@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Warning text...", Symbol("_class") -> "position-relative" )
+					@@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "A help text", Symbol("placeholder") -> "Error text...", Symbol("_class") -> "position-relative" )
 				}
 			}
 
@@ -104,16 +104,16 @@
 
 			<h4 id="helper-inputtype"><code>b4.inputType</code> <span class="def">@@(inputType: String, field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
 			<p>
-				It renders a simple input with a specific type attribute and it adds <code>class="form-control"</code> by default, but you can add an extra class with <code>'class -> "extra_class"</code>.
+				It renders a simple input with a specific type attribute and it adds <code>class="form-control"</code> by default, but you can add an extra class with <code>Symbol("class") -> "extra_class"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.inputType( "text", fooForm("name"), 'class -> "extra_class", '_label -> "Name", 'placeholder -> "John Doe" )
-				@b4.inputType( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
-				@b4.inputType( "password", fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@b4.inputType( "text", fooForm("name"), Symbol("class") -> "extra_class", Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
+				@b4.inputType( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+				@b4.inputType( "password", fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}{
-				@@b4.inputType( "text", fooForm("name"), 'class -> "extra_class", '_label -> "Name", 'placeholder -> "John Doe" )
-				@@b4.inputType( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-				@@b4.inputType( "password", fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@@b4.inputType( "text", fooForm("name"), Symbol("class") -> "extra_class", Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
+				@@b4.inputType( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+				@@b4.inputType( "password", fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}
 
 
@@ -122,9 +122,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="text"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.text( fooForm("name"), '_label -> "Name", 'placeholder -> "John Doe" )
+				@b4.text( fooForm("name"), Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
 			}{
-				@@b4.text( fooForm("name"), '_label -> "Name", 'placeholder -> "John Doe" )
+				@@b4.text( fooForm("name"), Symbol("_label") -> "Name", Symbol("placeholder") -> "John Doe" )
 			}
 
 
@@ -136,9 +136,9 @@
 				For security reasons, this helper doesn't display the possible value the field could have (for example when the form is reloaded after a validation failure).
 			</p>
 			@bsExampleWithCode {
-				@b4.password( fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@b4.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}{
-				@@b4.password( fooForm("password"), '_label -> "Password", '_help -> "With at least 8 characters" )
+				@@b4.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("_help") -> "With at least 8 characters" )
 			}
 
 
@@ -147,21 +147,21 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="file"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.file( fooForm("file"), '_label -> "File" )
-				@b4.file( fooForm("file"), '_label -> "File", 'class -> "form-control" )
+				@b4.file( fooForm("file"), Symbol("_label") -> "File" )
+				@b4.file( fooForm("file"), Symbol("_label") -> "File", Symbol("class") -> "form-control" )
 			}{
-				@@b4.file( fooForm("file"), '_label -> "File" )
-				@@b4.file( fooForm("file"), '_label -> "File", 'class -> "form-control" )
+				@@b4.file( fooForm("file"), Symbol("_label") -> "File" )
+				@@b4.file( fooForm("file"), Symbol("_label") -> "File", Symbol("class") -> "form-control" )
 			}
       <h5 id="helper-file-b4-custom">Bootstrap 4 custom file</h5>
 			<p>
-				For new Bootstrap 4 custom file, you only need to add <code>'_custom -> true</code>.
+				For new Bootstrap 4 custom file, you only need to add <code>Symbol("_custom") -> true</code>.
 				Additionally, you can use the argument <code>'placeholder</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.file( fooForm("file_custom"), '_label -> "File", '_custom -> true, 'placeholder -> "Select a file" )
+				@b4.file( fooForm("file_custom"), Symbol("_label") -> "File", Symbol("_custom") -> true, Symbol("placeholder") -> "Select a file" )
 			}{
-				@@b4.file( fooForm("file"), '_label -> "File", '_custom -> true, 'placeholder -> "Select a file" )
+				@@b4.file( fooForm("file"), Symbol("_label") -> "File", Symbol("_custom") -> true, Symbol("placeholder") -> "Select a file" )
 			}
 
 
@@ -170,9 +170,9 @@
 				It renders a textarea and it adds <code>class="form-control"</code> by default.
 			</p>
 			@bsExampleWithCode {
-				@b4.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
+				@b4.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
 			}{
-				@@b4.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
+				@@b4.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
 			}
 
 
@@ -185,7 +185,7 @@
 				The special <code>'_text</code> argument lets you put a text after the checkbox.
 			</p>
       <p>
-        Regarding to the <code>checked</code> attribute, if you want to set it to <strong>true</strong> as default, use <code>'_default -> true</code>.
+        Regarding to the <code>checked</code> attribute, if you want to set it to <strong>true</strong> as default, use <code>Symbol("_default") -> true</code>.
         And if you need to force its value use directly the <code>'checked</code> argument.
       </p>
 			<p>
@@ -193,41 +193,41 @@
 				<code>&lt;input type="hidden"&gt;</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.checkbox( fooForm("foo"), '_text -> "Remember me" )
+				@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me" )
 			}{
-				@@b4.checkbox( fooForm("foo"), '_text -> "Remember me" )
+				@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me" )
 
 				// uses "bar" as value for the checkbox
-				@@b4.checkbox( fooForm("foo"), '_text -> "Remember me", 'value -> "bar" )
+				@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("value") -> "bar" )
 
 				// checked by default (if the form is filled, this value will be taken)
-				@@b4.checkbox( fooForm("foo"), '_text -> "Remember me", '_default -> true )
+				@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("_default") -> true )
 
 				// always checked (even if the form has been filled with a false)
-				@@b4.checkbox( fooForm("foo"), '_text -> "Remember me", 'checked -> true )
+				@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("checked") -> true )
 
 				// disabled -> it will NOT be sent within the POST request
-				@@b4.checkbox( fooForm("foo"), '_text -> "Remember me", 'disabled -> true )
+				@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("disabled") -> true )
 
 				// readonly -> it will be sent within the POST request
-				@@b4.checkbox( fooForm("foo"), '_text -> "Remember me", 'readonly -> true )
+				@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Remember me", Symbol("readonly") -> true )
 			}
 			<p>
 				Note you can use any value for the <code>_text</code> argument.
 			</p>
 			@bsExampleWithCode {
-				@b4.checkbox( fooForm("foo"), '_text -> Html("""Do you want a beer? <i class="fa fa-beer"></i>""") )
+				@b4.checkbox( fooForm("foo"), Symbol("_text") -> Html("""Do you want a beer? <i class="fa fa-beer"></i>""") )
 			}{
-				@@b4.checkbox( fooForm("foo"), '_text -> Html("Do you want a beer? <i class=\"fa fa-beer\"></i>") )
+				@@b4.checkbox( fooForm("foo"), Symbol("_text") -> Html("Do you want a beer? <i class=\"fa fa-beer\"></i>") )
 			}
       <h5 id="helper-checkbox-b4-custom">Bootstrap 4 custom checkbox</h5>
 			<p>
-				For new Bootstrap 4 custom checkbox, you only need to add <code>'_custom -> true</code>.
+				For new Bootstrap 4 custom checkbox, you only need to add <code>Symbol("_custom") -> true</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.checkbox( fooForm("foo_checkbox_custom"), '_custom -> true, '_text -> Html("""Do you want a beer? <i class="fa fa-beer"></i>""") )
+				@b4.checkbox( fooForm("foo_checkbox_custom"), Symbol("_custom") -> true, Symbol("_text") -> Html("""Do you want a beer? <i class="fa fa-beer"></i>""") )
 			}{
-				@@b4.checkbox( fooForm("foo"), '_custom -> true, '_text -> Html("Do you want a beer? <i class=\"fa fa-beer\"></i>") )
+				@@b4.checkbox( fooForm("foo"), Symbol("_custom") -> true, Symbol("_text") -> Html("Do you want a beer? <i class=\"fa fa-beer\"></i>") )
 			}
 
 
@@ -240,40 +240,40 @@
 				It has an additional special <code>_inline</code> argument to make it an inline radio (for vertical and horizontal forms).
 			</p>
 			@bsExampleWithCode {
-				@b4.radio( fooForm("foo_radio1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+				@b4.radio( fooForm("foo_radio1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 			}{
 				@@opts = @@{ Seq("M"->"Male","F"->"Female") }
 
-				@@b4.radio( fooForm("foo"), options = opts, '_label -> "Radio Group" )
+				@@b4.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group" )
 
 				// an inline radio within a vertical or horizontal form
-				@@b4.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", '_inline -> true )
+				@@b4.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("_inline") -> true )
 
 				// with value "F" by default (if the form is filled, this value will be taken)
-				@@b4.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", 'value -> "F" )
+				@@b4.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("value") -> "F" )
 
 				// disabled -> it will NOT be sent within the POST request
-				@@b4.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", 'disabled -> true )
+				@@b4.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("disabled") -> true )
 
 				// readonly -> it will be sent within the POST request
-				@@b4.radio( fooForm("foo"), options = opts, '_label -> "Radio Group", 'readonly -> true )
+				@@b4.radio( fooForm("foo"), options = opts, Symbol("_label") -> "Radio Group", Symbol("readonly") -> true )
 			}
 			<p>
 				Note you can use any value for the <code>options</code> argument.
 			</p>
 			@bsExampleWithCode {
-				@b4.radio( fooForm("foo_radio2"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), '_label -> "What do you prefer?" )
+				@b4.radio( fooForm("foo_radio2"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), Symbol("_label") -> "What do you prefer?" )
 			}{
-				@@b4.radio( fooForm("foo"), options = Seq("B" -> Html("Beer <i class=\"fa fa-beer\"></i>"), "C" -> Html("Coffee <i class=\"fa fa-coffee\"></i>")), '_label -> "What do you prefer?" )
+				@@b4.radio( fooForm("foo"), options = Seq("B" -> Html("Beer <i class=\"fa fa-beer\"></i>"), "C" -> Html("Coffee <i class=\"fa fa-coffee\"></i>")), Symbol("_label") -> "What do you prefer?" )
 			}
       <h5 id="helper-radio-b4-custom">Bootstrap 4 custom radio</h5>
 			<p>
-				For new Bootstrap 4 custom radio, you only need to add <code>'_custom -> true</code>.
+				For new Bootstrap 4 custom radio, you only need to add <code>Symbol("_custom") -> true</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.radio( fooForm("foo_radio_custom"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), '_custom -> true, '_label -> "What do you prefer?" )
+				@b4.radio( fooForm("foo_radio_custom"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), Symbol("_custom") -> true, Symbol("_label") -> "What do you prefer?" )
 			}{
-				@@b4.radio( fooForm("foo"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), '_custom -> true, '_label -> "What do you prefer?" )
+				@@b4.radio( fooForm("foo"), options = Seq("B" -> Html("""Beer <i class="fa fa-beer"></i>"""), "C" -> Html("""Coffee <i class="fa fa-coffee"></i>""")), Symbol("_custom") -> true, Symbol("_label") -> "What do you prefer?" )
 			}
 
 			<h5 id="helper-radio-customizable" style="margin-top:40px"><code>b4.radio</code> <span class="def">@@(field: Field, args: (Symbol, Any)*)(content: Tuple6[Boolean, Boolean, String, String, Option[String], Map[Symbol, Any]] => Html)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h5>
@@ -282,14 +282,14 @@
 				If you need more versatility you can fully customize your radio options:
 			</p>
 			@bsExampleWithCode {
-				@b4.radio( fooForm("foo_radio3"), '_label -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
+				@b4.radio( fooForm("foo_radio3"), Symbol("_label") -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
 					@b4.radioOption("B", Html("""Beer <i class="fa fa-beer"></i>"""))
-					@b4.radioOption("B", Html("""Coffee <i class="fa fa-coffee"></i>"""), 'disabled -> true)
+					@b4.radioOption("B", Html("""Coffee <i class="fa fa-coffee"></i>"""), Symbol("disabled") -> true)
 				}
 			}{
-				@@b4.radio( fooForm("foo3"), '_label -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
+				@@b4.radio( fooForm("foo3"), Symbol("_label") -> "Ok, now that we're alone, what do you really prefer?" ) { implicit extraInfo =>
 					@@b4.radioOption("B", Html("Beer <i class=\"fa fa-beer\"></i>"))
-					@@b4.radioOption("B", Html("Coffee <i class=\"fa fa-coffee\"></i>"), 'disabled -> true)
+					@@b4.radioOption("B", Html("Coffee <i class=\"fa fa-coffee\"></i>"), Symbol("disabled") -> true)
 				}
 			}
 
@@ -302,19 +302,19 @@
 				one and a <code>&lt;input type="hidden"&gt;</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Disabled", 'disabled -> true )
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Readonly", 'readonly -> true )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Disabled", Symbol("disabled") -> true )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Readonly", Symbol("readonly") -> true )
 			}{
 				@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 
-				@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select" )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
 
 				// disabled -> it will NOT be sent within the POST request
-				@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select", 'disabled -> true )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("disabled") -> true )
 
 				// readonly -> it will be sent within the POST request
-				@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select", 'readonly -> true )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("readonly") -> true )
 			}
 			<p>
 				You can add a default first value using the argument <code>'_default</code> with a string.
@@ -324,11 +324,11 @@
 				and if any other option is selected this default one will not appear at all.
 			</p>
 			@bsExampleWithCode {
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "With default", '_default -> "Select an option" )
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "With default and Pears as value", '_default -> "Select an option", 'value -> "P" )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "With default", Symbol("_default") -> "Select an option" )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "With default and Pears as value", Symbol("_default") -> "Select an option", Symbol("value") -> "P" )
 			}{
-				@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select", '_default -> "Select an option" )
-				@@b4.select( fooForm("foo"), options = fruits, '_label -> "With default and Pears as value", '_default -> "Select an option", 'value -> "P" )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("_default") -> "Select an option" )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "With default and Pears as value", Symbol("_default") -> "Select an option", Symbol("value") -> "P" )
 			}
 
 			<p>
@@ -336,24 +336,24 @@
 				In that case, the <code>'_default</code> argument will be ignored.
 			</p>
 			@bsExampleWithCode {
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Select Multiple", 'multiple -> true )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select Multiple", Symbol("multiple") -> true )
 			}{
 				@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 
-				@@b4.select( fooForm("foo"), options = fruits, '_label -> "Fruits", 'multiple -> true )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Fruits", Symbol("multiple") -> true )
 
 				// with value "A" and "B" by default
 				// it is a string with every value separated by commas
-				@@b4.select( fooForm("foo"), options = fruits, '_label -> "Fruits", 'multiple -> true, 'value -> "A,B" )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Fruits", Symbol("multiple") -> true, Symbol("value") -> "A,B" )
 			}
       <h5 id="helper-select-b4-custom">Bootstrap 4 custom select</h5>
 			<p>
-				For new Bootstrap 4 custom select, you only need to add <code>'_custom -> true</code>.
+				For new Bootstrap 4 custom select, you only need to add <code>Symbol("_custom") -> true</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.select( fooForm("foo_select_custom"), options = fruits, '_custom -> true, '_label -> "Custom Select" )
+				@b4.select( fooForm("foo_select_custom"), options = fruits, Symbol("_custom") -> true, Symbol("_label") -> "Custom Select" )
 			}{
-				@@b4.select( fooForm("foo"), options = fruits, '_custom -> true, '_label -> "Custom Select" )
+				@@b4.select( fooForm("foo"), options = fruits, Symbol("_custom") -> true, Symbol("_label") -> "Custom Select" )
 			}
 
 			<h5 id="helper-select-customizable" style="margin-top:40px"><code>b4.select</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(content: Set[String] => Html)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h5>
@@ -362,22 +362,22 @@
 				If you need more versatility you can fully customize your select options:
 			</p>
 			@bsExampleWithCode {
-				@b4.select( fooForm("foo"), '_label -> "Grouped select" ) { implicit values =>
+				@b4.select( fooForm("foo"), Symbol("_label") -> "Grouped select" ) { implicit values =>
 				  <optgroup label="Group 1">
 				    @b4.selectOption("opt_1-1", "Option 1.1")
-				    @b4.selectOption("opt_1-2", "Option 1.2", 'disabled -> true)
+				    @b4.selectOption("opt_1-2", "Option 1.2", Symbol("disabled") -> true)
 				    @b4.selectOption("opt_1-3", "Option 1.3")
 				  </optgroup>
 				  <optgroup label="Group 2">
-				    @b4.selectOption("opt_2-1", "Option 2.1", 'disabled -> true)
+				    @b4.selectOption("opt_2-1", "Option 2.1", Symbol("disabled") -> true)
 				    @b4.selectOption("opt_2-2", "Option 2.2")
 				  </optgroup>
 				}
 
-				@b4.select( fooForm("foo"), '_label -> "Fruits select (lemon preselected)" ) { implicit values =>
+				@b4.select( fooForm("foo"), Symbol("_label") -> "Fruits select (lemon preselected)" ) { implicit values =>
 					<optgroup label="Citrus fruits">
 				    @fruitsWithCitrus.filter(_.isCitrus).map { citrus =>
-				      @b4.selectOption(citrus.id, citrus.name, 'selected -> (citrus.name == "Lemon"))
+				      @b4.selectOption(citrus.id, citrus.name, Symbol("selected") -> (citrus.name == "Lemon"))
 				    }
 					</optgroup>
 					<optgroup label="Rest of fruits">
@@ -387,14 +387,14 @@
 					</optgroup>
 				}
 			}{
-				@@b4.select( fooForm("foo"), '_label -> "Grouped select" ) { implicit values =>
+				@@b4.select( fooForm("foo"), Symbol("_label") -> "Grouped select" ) { implicit values =>
 				  <optgroup label="Group 1">
 				    @@b4.selectOption("opt_1-1", "Option 1.1")
-				    @@b4.selectOption("opt_1-2", "Option 1.2", 'disabled -> true)
+				    @@b4.selectOption("opt_1-2", "Option 1.2", Symbol("disabled") -> true)
 				    @@b4.selectOption("opt_1-3", "Option 1.3")
 				  </optgroup>
 				  <optgroup label="Group 2">
-				    @@b4.selectOption("opt_2-1", "Option 2.1", 'disabled -> true)
+				    @@b4.selectOption("opt_2-1", "Option 2.1", Symbol("disabled") -> true)
 				    @@b4.selectOption("opt_2-2", "Option 2.2")
 				  </optgroup>
 				}
@@ -409,10 +409,10 @@
 					Fruit(5L, "Banana", false)
 				)}
 
-				@@b4.select( fooForm("foo"), '_label -> "Fruits select (lemon preselected)" ) { implicit values =>
+				@@b4.select( fooForm("foo"), Symbol("_label") -> "Fruits select (lemon preselected)" ) { implicit values =>
 					<optgroup label="Citrus fruits">
 				    @@fruitsWithCitrus.filter(_.isCitrus).map { citrus =>
-				      @@b4.selectOption(citrus.id, citrus.name, 'selected -> (citrus.name == "Lemon"))
+				      @@b4.selectOption(citrus.id, citrus.name, Symbol("selected") -> (citrus.name == "Lemon"))
 				    }
 					</optgroup>
 					<optgroup label="Rest of fruits">
@@ -429,7 +429,7 @@
 				It simply renders a hidden input.
 			</p>
 			@code {
-				@@b4.hidden("fooName", "fooValue", 'fooAttr -> "fooAttrValue")
+				@@b4.hidden("fooName", "fooValue", Symbol("fooAttr") -> "fooAttrValue")
 			}
 			<p>Renders to:</p>
 			@code {
@@ -445,7 +445,7 @@
         <code>'value</code>. Finally, take into account that every "underscored" argument (with "_" as preffix) will be removed.
       </p>
 			@code {
-				@@b4.hidden( fooForm("name"), '_label -> "Name", 'value -> "defaultValue", 'placeholder -> "John Doe" )
+				@@b4.hidden( fooForm("name"), Symbol("_label") -> "Name", Symbol("value") -> "defaultValue", Symbol("placeholder") -> "John Doe" )
 			}
 			<p>Renders to:</p>
 			@code {
@@ -478,9 +478,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="color"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.color( fooForm("color"), '_label -> "Color", 'value -> "#3264c8" )
+				@b4.color( fooForm("color"), Symbol("_label") -> "Color", Symbol("value") -> "#3264c8" )
 			}{
-				@@b4.color( fooForm("color"), '_label -> "Color", 'value -> "#3264c8" )
+				@@b4.color( fooForm("color"), Symbol("_label") -> "Color", Symbol("value") -> "#3264c8" )
 			}
 
 			<h4 id="html5-date"><code>b4.date</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -488,9 +488,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="date"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.date( fooForm("date"), '_label -> "Date" )
+				@b4.date( fooForm("date"), Symbol("_label") -> "Date" )
 			}{
-				@@b4.date( fooForm("date"), '_label -> "Date" )
+				@@b4.date( fooForm("date"), Symbol("_label") -> "Date" )
 			}
 
 			<h4 id="html5-datetime"><code>b4.datetime</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -498,9 +498,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="datetime"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.datetime( fooForm("datetime"), '_label -> "Datetime" )
+				@b4.datetime( fooForm("datetime"), Symbol("_label") -> "Datetime" )
 			}{
-				@@b4.datetime( fooForm("datetime"), '_label -> "Datetime" )
+				@@b4.datetime( fooForm("datetime"), Symbol("_label") -> "Datetime" )
 			}
 
 			<h4 id="html5-datetime-local"><code>b4.datetimeLocal</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -508,9 +508,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="datetime-local"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.datetimeLocal( fooForm("datetimeLocal"), '_label -> "Datetime-Local" )
+				@b4.datetimeLocal( fooForm("datetimeLocal"), Symbol("_label") -> "Datetime-Local" )
 			}{
-				@@b4.datetimeLocal( fooForm("datetimeLocal"), '_label -> "Datetime-Local" )
+				@@b4.datetimeLocal( fooForm("datetimeLocal"), Symbol("_label") -> "Datetime-Local" )
 			}
 
 			<h4 id="html5-email"><code>b4.email</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -518,9 +518,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="email"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com", 'required -> true )
+				@b4.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com", Symbol("required") -> true )
 			}{
-				@@b4.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
+				@@b4.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
 			}
 
 			<h4 id="html5-month"><code>b4.month</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -528,9 +528,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="month"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.month( fooForm("month"), '_label -> "Month" )
+				@b4.month( fooForm("month"), Symbol("_label") -> "Month" )
 			}{
-				@@b4.month( fooForm("month"), '_label -> "Month" )
+				@@b4.month( fooForm("month"), Symbol("_label") -> "Month" )
 			}
 
 			<h4 id="html5-number"><code>b4.number</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -538,9 +538,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="number"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.number( fooForm("number"), '_label -> "Number (0 to 50 with intervals of 5)", 'min -> 0, 'max -> 50, 'step -> 5 )
+				@b4.number( fooForm("number"), Symbol("_label") -> "Number (0 to 50 with intervals of 5)", Symbol("min") -> 0, Symbol("max") -> 50, Symbol("step") -> 5 )
 			}{
-				@@b4.number( fooForm("number"), '_label -> "Number", 'min -> 0, 'max -> 50, 'step -> 5 )
+				@@b4.number( fooForm("number"), Symbol("_label") -> "Number", Symbol("min") -> 0, Symbol("max") -> 50, Symbol("step") -> 5 )
 			}
 
 			<h4 id="html5-range"><code>b4.range</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -548,9 +548,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="range"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.range( fooForm("range"), '_label -> "Range (0 to 50)", 'min -> 0, 'max -> 50 )
+				@b4.range( fooForm("range"), Symbol("_label") -> "Range (0 to 50)", Symbol("min") -> 0, Symbol("max") -> 50 )
 			}{
-				@@b4.range( fooForm("range"), '_label -> "Range", 'min -> 0, 'max -> 50 )
+				@@b4.range( fooForm("range"), Symbol("_label") -> "Range", Symbol("min") -> 0, Symbol("max") -> 50 )
 			}
 
 			<h4 id="html5-search"><code>b4.search</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -558,9 +558,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="search"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.search( fooForm("search"), '_label -> "Search" )
+				@b4.search( fooForm("search"), Symbol("_label") -> "Search" )
 			}{
-				@@b4.search( fooForm("search"), '_label -> "Search" )
+				@@b4.search( fooForm("search"), Symbol("_label") -> "Search" )
 			}
 
 			<h4 id="html5-tel"><code>b4.tel</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -568,9 +568,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="tel"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.tel( fooForm("tel"), '_label -> "Telephone" )
+				@b4.tel( fooForm("tel"), Symbol("_label") -> "Telephone" )
 			}{
-				@@b4.tel( fooForm("tel"), '_label -> "Telephone" )
+				@@b4.tel( fooForm("tel"), Symbol("_label") -> "Telephone" )
 			}
 
 			<h4 id="html5-time"><code>b4.time</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -578,9 +578,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="time"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.time( fooForm("time"), '_label -> "Time" )
+				@b4.time( fooForm("time"), Symbol("_label") -> "Time" )
 			}{
-				@@b4.time( fooForm("time"), '_label -> "Time" )
+				@@b4.time( fooForm("time"), Symbol("_label") -> "Time" )
 			}
 
 			<h4 id="html5-url"><code>b4.url</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -588,9 +588,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="url"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.url( fooForm("url"), '_label -> "URL" )
+				@b4.url( fooForm("url"), Symbol("_label") -> "URL" )
 			}{
-				@@b4.url( fooForm("url"), '_label -> "URL" )
+				@@b4.url( fooForm("url"), Symbol("_label") -> "URL" )
 			}
 
 			<h4 id="html5-week"><code>b4.week</code> <span class="def">@@(field: Field, args: (Symbol,Any)*)(implicit handler: BSFieldConstructor, @BSVersion.msgsArg)</span></h4>
@@ -598,9 +598,9 @@
 				It is a short version of <code>b4.inputType</code> for <code>type="week"</code>.
 			</p>
 			@bsExampleWithCode {
-				@b4.week( fooForm("week"), '_label -> "Week" )
+				@b4.week( fooForm("week"), Symbol("_label") -> "Week" )
 			}{
-				@@b4.week( fooForm("week"), '_label -> "Week" )
+				@@b4.week( fooForm("week"), Symbol("_label") -> "Week" )
 			}
 
 
@@ -634,11 +634,11 @@
 			</p>
 			@bsExampleWithCode {
 				@b4.static(Html("Label with icon <i class=\"fa fa-beer\"></i>")){ <a href="#">Basic control with label</a> }
-				@b4.static("Hidden label", '_hideLabel -> true){ <a href="#">Basic control with hidden label</a> }
+				@b4.static("Hidden label", Symbol("_hideLabel") -> true){ <a href="#">Basic control with hidden label</a> }
 				@b4.static(){ <a href="#">Basic control without label</a> }
 			}{
 				@@b4.static(Html("Label with icon <i class=\"fa fa-beer\"></i>")){ <a href="#">Basic control with label</a> }
-				@@b4.static("Hidden label", '_hideLabel -> true){ <a href="#">Basic control with hidden label</a> }
+				@@b4.static("Hidden label", Symbol("_hideLabel") -> true){ <a href="#">Basic control with hidden label</a> }
 				@@b4.static(){ <a href="#">Basic control without label</a> }
 			}
 
@@ -649,9 +649,9 @@
 				render whatever you want.
 			</p>
 			@bsExampleWithCode {
-				@b4.buttonType("submit", 'class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Sign in }
+				@b4.buttonType("submit", Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Sign in }
 			}{
-				@@b4.buttonType("submit", 'class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Sign in }
+				@@b4.buttonType("submit", Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Sign in }
 			}
 
 			<h4 id="more-submit"><code>b4.submit</code> <span class="def">@@(args: (Symbol,Any)*)(text: => Html)(implicit fc: BSFieldConstructor)</span></h4>
@@ -659,9 +659,9 @@
 				It is a short version of b4.buttonType for type="submit".
 			</p>
 			@bsExampleWithCode {
-				@b4.submit('class -> "btn btn-primary"){ <i class="fa fa-ok"></i> Sign in }
+				@b4.submit(Symbol("class") -> "btn btn-primary"){ <i class="fa fa-ok"></i> Sign in }
 			}{
-				@@b4.submit('class -> "btn btn-primary"){ <i class="fa fa-ok"></i> Sign in }
+				@@b4.submit(Symbol("class") -> "btn btn-primary"){ <i class="fa fa-ok"></i> Sign in }
 			}
 
 
@@ -670,9 +670,9 @@
 				It is a short version of b4.buttonType for type="reset".
 			</p>
 			@bsExampleWithCode {
-				@b4.reset('class -> "btn btn-danger"){ <i class="fa fa-remove"></i> Reset }
+				@b4.reset(Symbol("class") -> "btn btn-danger"){ <i class="fa fa-remove"></i> Reset }
 			}{
-				@@b4.reset('class -> "btn btn-danger"){ <i class="fa fa-remove"></i> Reset }
+				@@b4.reset(Symbol("class") -> "btn btn-danger"){ <i class="fa fa-remove"></i> Reset }
 			}
 
 			<h4 id="more-button"><code>b4.button</code> <span class="def">@@(args: (Symbol,Any)*)(text: => Html)(implicit fc: BSFieldConstructor)</span></h4>
@@ -680,9 +680,9 @@
 				It is a short version of b4.buttonType for type="button".
 			</p>
 			@bsExampleWithCode {
-				@b4.button('class -> "btn btn-secondary"){ <i class="fa fa-heart"></i> Favorite }
+				@b4.button(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-heart"></i> Favorite }
 			}{
-				@@b4.button('class -> "btn btn-secondary"){ <i class="fa fa-heart"></i> Favorite }
+				@@b4.button(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-heart"></i> Favorite }
 			}
 
 
@@ -691,12 +691,12 @@
 				It renders whatever you want within a <code>form-group</code> div.
 			</p>
 			@bsExampleWithCode {
-				@b4.free('_id -> "idFormGroup") {
+				@b4.free(Symbol("_id") -> "idFormGroup") {
 					<button type="submit" class="btn btn-primary"> <i class="fa fa-ok"></i> Save changes</button>
 					<a class="btn btn-secondary"> <i class="fa fa-remove"></i> Cancel</a>
 				}
 			}{
-				@@b4.free('_id -> "idFormGroup") {
+				@@b4.free(Symbol("_id") -> "idFormGroup") {
 					<button type="submit" class="btn btn-primary"> <i class="fa fa-ok"></i> Save changes</button>
 					<a class="btn btn-secondary"> <i class="fa fa-remove"></i> Cancel</a>
 				}
@@ -721,7 +721,7 @@
 				It is useful for <strong>input groups</strong> and <strong>inputs with validation states and feedback tooltips</strong>.
 			</p>
 			@bsExampleWithCode {
-				@b4.inputWrapped( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" ) { input =>
+				@b4.inputWrapped( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" ) { input =>
 					<div class="input-group">
 					  <div class="input-group-prepend">
 					  	<span class="input-group-text">@@</span>
@@ -740,7 +740,7 @@
           </div>
 				}
 			}{
-				@@b4.inputWrapped( "email", fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" ) { input =>
+				@@b4.inputWrapped( "email", fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" ) { input =>
 					<div class="input-group">
 						<div class="input-group-prepend">
 							<span class="input-group-text">@@@@</span>

--- a/play27-bootstrap4/sample/app/views/extendIt.scala.html
+++ b/play27-bootstrap4/sample/app/views/extendIt.scala.html
@@ -18,17 +18,17 @@
 
 		<h2 id="create-helper">Create your own helper</h2>
 		@bsExample {
-			@b4.my.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+			@b4.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
 		}
 		@code {
-			@@b4.my.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
+			@@b4.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
 		}
 
 		<h3 id="input-wrapped">The use of <code>b4.inputWrapped</code></h3>
 		@bsExampleWithCode {
-			@b4.my.number( fooForm("foo"), '_label -> "Number", 'value -> 0 )
+			@b4.my.number( fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0 )
 		}{
-			@@b4.my.number( fooForm("foo"), '_label -> "Number", 'value -> 0 )
+			@@b4.my.number( fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0 )
 		}
 
 		<h3 id="multifield">Create your multifield helper</h3>
@@ -39,8 +39,8 @@
 	<h2 id="create-field-constructor">Create your own field constructor</h2>
 	@bsExampleWithCode {
 		@b4.my.vertical.form(routes.Application.extendIt) { implicit myfc =>
-			@b4.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@mail.com" )
-			@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file...", '_success -> "Great!!" )
+			@b4.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("_error") -> "And error occurred!", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "example@mail.com" )
+			@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file...", Symbol("_success") -> "Great!!" )
 		}
 	}{
 		<div class="my-form-group form-group has-danger" id="foo_field">
@@ -67,14 +67,14 @@
 	@code {
 		@@import b4.my.vertical.fieldConstructor		// Declare it as default
 
-		@@b4.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@@mail.com" )
+		@@b4.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("_error") -> "And error occurred!", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "example@@mail.com" )
 	}
 	<p>
 		Or even using it for specific forms:
 	</p>
 	@code {
 		@@b4.my.vertical.form(routes.Application.extendIt) { implicit myfc =>
-			@@b4.my.email( fooForm("foo"), '_label -> "Email", '_error -> "And error occurred!", '_showConstraints -> true, 'placeholder -> "example@@mail.com" )
+			@@b4.my.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("_error") -> "And error occurred!", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "example@@mail.com" )
 		}
 	}
 

--- a/play27-bootstrap4/sample/app/views/horizontal.scala.html
+++ b/play27-bootstrap4/sample/app/views/horizontal.scala.html
@@ -14,40 +14,40 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b4.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b4.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
 			</div>
 			<div class="col-md-6">
-				@b4.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-				@b4.file( fooForm("foo"), '_label -> "File" )
+				@b4.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+				@b4.file( fooForm("foo"), Symbol("_label") -> "File" )
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b4.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-		@@b4.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-		@@b4.file( fooForm("foo"), '_label -> "File" )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b4.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+		@@b4.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+		@@b4.file( fooForm("foo"), Symbol("_label") -> "File" )
 	}
 
 	<h3 id="more-options">More options</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b4.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-				@b4.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			</div>
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), 'placeholder -> "Without label" )
-				@b4.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control form-control-lg", 'placeholder -> "An awesome field..." )
+				@b4.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control form-control-lg", Symbol("placeholder") -> "An awesome field..." )
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b4.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-		@@b4.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-		@@b4.text( fooForm("foo"), 'placeholder -> "Without label" )
-		@@b4.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control form-control-lg", 'placeholder -> "An awesome field..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+		@@b4.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control form-control-lg", Symbol("placeholder") -> "An awesome field..." )
 	}
 
 
@@ -55,69 +55,69 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-				@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-				@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+				@b4.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+				@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+				@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 			</div>
 			<div class="col-md-6">
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 			</div>
 		</div>
 	}{
-		@@b4.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-		@@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-		@@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+		@@b4.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+		@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+		@@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 
 		@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 		...
-		@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-		@@b4.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 	}
 
 	<h3 id="disabled-readonly-attributes">Disabled and readonly attributes</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-				@b4.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+				@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
 			</div>
 			<div class="col-md-6">
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-		@@b4.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-		@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+		@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 	}
 
 	<h3 id="validation-states">Validation states</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-				@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text..." )
 			</div>
 			<div class="col-md-6">
-				@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", '_feedbackTooltip -> true) { implicit fc =>
-					@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text...", '_class -> "position-relative" )
-					@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text...", '_class -> "position-relative" )
-					@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text...", '_class -> "position-relative" )
+				@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", Symbol("_feedbackTooltip") -> true) { implicit fc =>
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text...", Symbol("_class") -> "position-relative" )
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text...", Symbol("_class") -> "position-relative" )
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text...", Symbol("_class") -> "position-relative" )
 				}
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-		@@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-		@@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text..." )
 
 		// With feedback tooltips
-		@@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", '_feedbackTooltip -> true) { implicit fc =>
-			@@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text...", '_class -> "position-relative" )
-			@@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text...", '_class -> "position-relative" )
-			@@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text...", '_class -> "position-relative" )
+		@@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", Symbol("_feedbackTooltip") -> true) { implicit fc =>
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text...", Symbol("_class") -> "position-relative" )
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text...", Symbol("_class") -> "position-relative" )
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text...", Symbol("_class") -> "position-relative" )
 		}
 	}
 
@@ -125,29 +125,29 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true, '_custom -> true )
-				@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group", '_custom -> true )
+				@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true, Symbol("_custom") -> true )
+				@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group", Symbol("_custom") -> true )
 			</div>
 			<div class="col-md-6">
-				@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", '_custom -> true) { implicit fc =>
-					@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select" )
-					@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file..." )
+				@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", Symbol("_custom") -> true) { implicit fc =>
+					@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select" )
+					@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file..." )
 				}
 			</div>
 		</div>
 }{
-		@@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true, '_custom -> true )
-		@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group", '_custom -> true )
-		@@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select", '_custom -> true )
-		@@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file...", '_custom -> true )
+		@@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true, Symbol("_custom") -> true )
+		@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group", Symbol("_custom") -> true )
+		@@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select", Symbol("_custom") -> true )
+		@@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file...", Symbol("_custom") -> true )
 
 		Or
 
-		@@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", '_custom -> true) { implicit fc =>
-			@@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true )
-			@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
-			@@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select" )
-			@@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file..." )
+		@@b4.horizontal.form(routes.Application.horizontal, "col-md-4", "col-md-8", Symbol("_custom") -> true) { implicit fc =>
+			@@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+			@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
+			@@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select" )
+			@@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file..." )
 		}
 }
 
@@ -155,7 +155,7 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.inputWrapped( "email", fooForm("foo"), '_label -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+				@b4.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 					<div class="input-group">
 						<div class="input-group-prepend">
 							<span class="input-group-text">@@</span>
@@ -163,7 +163,7 @@
 						@input
 					</div>
 				}
-				@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+				@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 					<div class="input-number input-group">
 						<div class="input-group-prepend">
 							<span class="input-group-text input-number-minus"><i class="fa fa-minus"></i></span>
@@ -176,7 +176,7 @@
 				}
 			</div>
 			<div class="col-md-6">
-				@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+				@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 					<div class="input-group">
 						<div class="input-group-prepend">
 							<span class="input-group-text"><i class="fa fa-star"></i></span>
@@ -200,7 +200,7 @@
 			</div>
 		</div>
 	}{
-		@@b4.inputWrapped( "email", fooForm("foo"), '_label -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+		@@b4.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 			<div class="input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text">@@@@</span>
@@ -208,7 +208,7 @@
 				@@input
 			</div>
 		}
-		@@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+		@@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 			<div class="input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text"><i class="fa fa-star"></i></span>
@@ -219,7 +219,7 @@
 				</div>
 			</div>
 		}
-		@@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+		@@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 			<div class="input-number input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text input-number-minus"><i class="fa fa-minus"></i></span>
@@ -237,7 +237,7 @@
 		<div class="row">
 			<div class="col-md-6">
 				@b4.static("Static HTML"){ <a href="#"><i class="fa fa-star"></i> This is a link</a> }
-				@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
+				@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
 				@b4.free() {
 					<button type="submit" class="btn btn-primary"> <i class="fa fa-ok"></i> Save changes</button>
 					<a class="btn btn-secondary" href> <i class="fa fa-remove"></i> Cancel</a>
@@ -246,7 +246,7 @@
 		</div>
 	}{
 		@@b4.static("Static HTML"){ <a href="#"><i class="fa fa-star"></i> This is a link</a> }
-		@@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
+		@@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
 		@@b4.free() {
 			<button type="submit" class="btn btn-primary"> <i class="fa fa-ok"></i> Save changes</button>
 			<a class="btn btn-secondary" href> <i class="fa fa-remove"></i> Cancel</a>

--- a/play27-bootstrap4/sample/app/views/index.scala.html
+++ b/play27-bootstrap4/sample/app/views/index.scala.html
@@ -40,51 +40,51 @@
 		<div class="tab-pane active" id="vertical" role="tabpanel">
 			@bsExampleWithCode {
 				@b4.vertical.form(routes.Application.index) { implicit vfc =>
-					@b4.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
-					@b4.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@b4.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@b4.submit('class -> "btn btn-secondary"){ Sign in }
+					@b4.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+					@b4.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@b4.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 				}
 			}{
 				@@b4.vertical.form(routes.Application.index) { implicit vfc =>
-					@@b4.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-					@@b4.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@@b4.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@@b4.submit('class -> "btn btn-secondary"){ Sign in }
+					@@b4.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+					@@b4.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@@b4.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 				}
 			}
 		</div>
 		<div class="tab-pane" id="horizontal" role="tabpanel">
 			@bsExampleWithCode {
 				@b4.horizontal.form(routes.Application.index, "col-md-2", "col-md-10") { implicit hfc =>
-					@b4.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
-					@b4.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@b4.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@b4.submit('class -> "btn btn-secondary"){ Sign in }
+					@b4.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+					@b4.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@b4.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 				}
 			}{
 				@@b3.horizontal.form(routes.Application.index, "col-md-2", "col-md-10") { implicit hfc =>
-					@@b4.email( fooForm("email"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-					@@b4.password( fooForm("password"), '_label -> "Password", 'placeholder -> "Password" )
-					@@b4.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@@b4.submit('class -> "btn btn-secondary"){ Sign in }
+					@@b4.email( fooForm("email"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+					@@b4.password( fooForm("password"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+					@@b4.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 				}
 			}
 		</div>
 		<div class="tab-pane" id="inline" role="tabpanel">
 			@bsExampleWithCode {
 				@b4.inline.form(routes.Application.index) { implicit ifc =>
-					@b4.email( fooForm("email"), '_hiddenLabel -> "Email", 'placeholder -> "example@mail.com" )
-					@b4.password( fooForm("password"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-					@b4.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@b4.submit('class -> "btn btn-secondary"){ Sign in }
+					@b4.email( fooForm("email"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+					@b4.password( fooForm("password"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+					@b4.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 				}
 			}{
 				@@b4.inline.form(routes.Application.index) { implicit ifc =>
-					@@b4.email( fooForm("email"), '_hiddenLabel -> "Email", 'placeholder -> "example@@mail.com" )
-					@@b4.password( fooForm("password"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-					@@b4.checkbox( fooForm("remember"), '_text -> "Remember me", 'value -> true )
-					@@b4.submit('class -> "btn btn-secondary"){ Sign in }
+					@@b4.email( fooForm("email"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+					@@b4.password( fooForm("password"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+					@@b4.checkbox( fooForm("remember"), Symbol("_text") -> "Remember me", Symbol("value") -> true )
+					@@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 				}
 			}
 		</div>

--- a/play27-bootstrap4/sample/app/views/inline.scala.html
+++ b/play27-bootstrap4/sample/app/views/inline.scala.html
@@ -13,100 +13,100 @@
 	<h3 id="simple-inputs">Simple inputs</h3>
 	@bsExampleWithCode {
 		<div class="form-inline">
-			@b4.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-			@b4.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@mail.com" )
-			@b4.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-			@b4.file( fooForm("foo"), '_hiddenLabel -> "File" )
+			@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@b4.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+			@b4.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+			@b4.file( fooForm("foo"), Symbol("_hiddenLabel") -> "File" )
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b4.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@@mail.com" )
-		@@b4.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-		@@b4.file( fooForm("foo"), '_hiddenLabel -> "File" )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b4.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+		@@b4.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+		@@b4.file( fooForm("foo"), Symbol("_hiddenLabel") -> "File" )
 	}
 
 	<h3 id="more-options">More options</h3>
 	@bsExampleWithCode {
 		<div class="form-inline">
-			@b4.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-			@b4.text( fooForm("foo"), '_label -> "Show label", '_showLabel -> true, 'placeholder -> "Show label" )
-			@b4.text( fooForm("foo"), '_hiddenLabel -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-			@b4.text( fooForm("foo"), '_hiddenLabel -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-			@b4.text( fooForm("foo"), 'placeholder -> "Without label" )
-			@b4.text( fooForm("foo"), '_hiddenLabel -> "A big text", 'class -> "form-control form-control-lg", 'placeholder -> "An awesome field..." )
+			@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@b4.text( fooForm("foo"), Symbol("_label") -> "Show label", Symbol("_showLabel") -> true, Symbol("placeholder") -> "Show label" )
+			@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+			@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+			@b4.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+			@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "A big text", Symbol("class") -> "form-control form-control-lg", Symbol("placeholder") -> "An awesome field..." )
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b4.text( fooForm("foo"), '_label -> "Show label", '_showLabel -> true, 'placeholder -> "Show label" )
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-		@@b4.text( fooForm("foo"), 'placeholder -> "Without label" )
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "A big text", 'class -> "form-control form-control-lg", 'placeholder -> "An awesome field..." )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Show label", Symbol("_showLabel") -> true, Symbol("placeholder") -> "Show label" )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+		@@b4.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "A big text", Symbol("class") -> "form-control form-control-lg", Symbol("placeholder") -> "An awesome field..." )
 	}
 
 
 	<h3 id="textareas-checkboxes-radios-selects">Textareas, checkboxes, radio buttons and selects</h3>
 	@bsExampleWithCode {
 		<div class="form-inline">
-			@b4.textarea( fooForm("foo"), '_hiddenLabel -> "Textarea", 'rows -> 3 )
-			@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
+			@b4.textarea( fooForm("foo"), Symbol("_hiddenLabel") -> "Textarea", Symbol("rows") -> 3 )
+			@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
 			@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female") )
-			@b4.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select" )
-			@b4.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Multiple Select", 'multiple -> true )
+			@b4.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select" )
+			@b4.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Multiple Select", Symbol("multiple") -> true )
 		</div>
 	}{
-		@@b4.textarea( fooForm("foo"), '_hiddenLabel -> "Textarea", 'rows -> 3 )
-		@@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
+		@@b4.textarea( fooForm("foo"), Symbol("_hiddenLabel") -> "Textarea", Symbol("rows") -> 3 )
+		@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
 		@@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female") )
 
 		@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 		...
-		@@b4.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select" )
-		@@b4.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Multiple Select", 'multiple -> true )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select" )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Multiple Select", Symbol("multiple") -> true )
 	}
 
 	<h3 id="disabled-readonly-attributes">Disabled and readonly attributes</h3>
 	@bsExampleWithCode {
 		<div class="form-inline">
-			@b4.text( fooForm("foo"), '_hiddenLabel -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-			@b4.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-			@b4.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+			@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+			@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+			@b4.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-		@@b4.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-		@@b4.select( fooForm("foo"), options = fruits, '_hiddenLabel -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+		@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_hiddenLabel") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 	}
 
 	<h3 id="validation-states">Validation states</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-12 form-inline">
-				@b4.text( fooForm("foo"), '_hiddenLabel -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-				@b4.text( fooForm("foo"), '_hiddenLabel -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@b4.text( fooForm("foo"), '_hiddenLabel -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+				@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 			</div>
 		</div>
 		<div class="row">
 			<div class="col-md-12 form-inline">
-				@b4.inline.form(routes.Application.inline, '_feedbackTooltip -> true) { implicit fc =>
-					@b4.text( fooForm("foo"), '_hiddenLabel -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-					@b4.text( fooForm("foo"), '_hiddenLabel -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-					@b4.text( fooForm("foo"), '_hiddenLabel -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+				@b4.inline.form(routes.Application.inline, Symbol("_feedbackTooltip") -> true) { implicit fc =>
+					@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+					@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+					@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 				}
 			</div>
 		</div>
 
 	}{
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-		@@b4.text( fooForm("foo"), '_hiddenLabel -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text..." )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+		@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text..." )
 
 		// With feedback tooltips
-		@@b4.inline.form(routes.Application.inline, '_feedbackTooltip -> true) { implicit fc =>
-			@@b4.text( fooForm("foo"), '_hiddenLabel -> "Success", '_success -> true, 'placeholder -> "Success text...", '_class -> "position-relative" )
-			@@b4.text( fooForm("foo"), '_hiddenLabel -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text...", '_class -> "position-relative" )
-			@@b4.text( fooForm("foo"), '_hiddenLabel -> "Error", '_error -> "An error occurred!", 'placeholder -> "Error text...", '_class -> "position-relative" )
+		@@b4.inline.form(routes.Application.inline, Symbol("_feedbackTooltip") -> true) { implicit fc =>
+			@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Success", Symbol("_success") -> true, Symbol("placeholder") -> "Success text...", Symbol("_class") -> "position-relative" )
+			@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text...", Symbol("_class") -> "position-relative" )
+			@@b4.text( fooForm("foo"), Symbol("_hiddenLabel") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("placeholder") -> "Error text...", Symbol("_class") -> "position-relative" )
 		}
 	}
 
@@ -114,36 +114,36 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-12 form-inline">
-				@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true, '_custom -> true )
-				@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group", '_custom -> true )
+				@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true, Symbol("_custom") -> true )
+				@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group", Symbol("_custom") -> true )
 			</div>
 			<div class="col-md-12 form-inline">
-				@b4.inline.form(routes.Application.inline, '_custom -> true) { implicit fc =>
-					@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select" )
-					@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file..." )
+				@b4.inline.form(routes.Application.inline, Symbol("_custom") -> true) { implicit fc =>
+					@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select" )
+					@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file..." )
 				}
 			</div>
 		</div>
 }{
-		@@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true, '_custom -> true )
-		@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group", '_custom -> true )
-		@@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select", '_custom -> true )
-		@@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file...", '_custom -> true )
+		@@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true, Symbol("_custom") -> true )
+		@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group", Symbol("_custom") -> true )
+		@@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select", Symbol("_custom") -> true )
+		@@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file...", Symbol("_custom") -> true )
 
 		Or
 
-		@@b4.inline.form(routes.Application.inline, '_custom -> true) { implicit fc =>
-			@@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true )
-			@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
-			@@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select" )
-			@@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file..." )
+		@@b4.inline.form(routes.Application.inline, Symbol("_custom") -> true) { implicit fc =>
+			@@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+			@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
+			@@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select" )
+			@@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file..." )
 		}
 }
 
 	<h3 id="customize">Customize them</h3>
 	@bsExampleWithCode {
 		<div class="form-inline">
-			@b4.inputWrapped( "email", fooForm("foo"), '_hiddenLabel -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+			@b4.inputWrapped( "email", fooForm("foo"), Symbol("_hiddenLabel") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 				<div class="input-group">
 					<div class="input-group-prepend">
 						<span class="input-group-text">@@</span>
@@ -151,7 +151,7 @@
 					@input
 				</div>
 			}
-			@b4.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+			@b4.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 				<div class="input-group">
 					<div class="input-group-prepend">
 						<span class="input-group-text"><i class="fa fa-star"></i></span>
@@ -172,7 +172,7 @@
 					</div>
 				</div>
 			}
-			@b4.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Number", 'value -> 0 ) { input =>
+			@b4.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Number", Symbol("value") -> 0 ) { input =>
 				<div class="input-number input-group">
 					<div class="input-group-prepend">
 						<span class="input-group-text input-number-minus"><i class="fa fa-minus"></i></span>
@@ -185,7 +185,7 @@
 			}
 		</div>
 	}{
-		@@b4.inputWrapped( "email", fooForm("foo"), '_hiddenLabel -> "Simple input group", 'placeholder -> "Custom input group for email..." ) { input =>
+		@@b4.inputWrapped( "email", fooForm("foo"), Symbol("_hiddenLabel") -> "Simple input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 			<div class="input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text">@@@@</span>
@@ -193,7 +193,7 @@
 				@@input
 			</div>
 		}
-		@@b4.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+		@@b4.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 			<div class="input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text"><i class="fa fa-star"></i></span>
@@ -204,7 +204,7 @@
 				</div>
 			</div>
 		}
-		@@b4.inputWrapped( "text", fooForm("foo"), '_hiddenLabel -> "Number", 'value -> 0 ) { input =>
+		@@b4.inputWrapped( "text", fooForm("foo"), Symbol("_hiddenLabel") -> "Number", Symbol("value") -> 0 ) { input =>
 			<div class="input-number input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text input-number-minus"><i class="fa fa-minus"></i></span>
@@ -219,9 +219,9 @@
 
 	<h3 id="more-helpers">More helpers</h3>
 	@bsExampleWithCode {
-		@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
+		@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
 	}{
-		@@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
+		@@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
 	}
 
 }

--- a/play27-bootstrap4/sample/app/views/mixed.scala.html
+++ b/play27-bootstrap4/sample/app/views/mixed.scala.html
@@ -14,17 +14,17 @@
 	<h3 id="simple-form">A simple horizontal form</h3>
 	@bsExampleWithCode {
 		@b4.form(routes.Application.mixed) {
-			@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@b4.select( fooForm("foo"), options = fruits, '_label -> "Select a fruit" )
-			@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-			@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
+			@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select a fruit" )
+			@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+			@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
 		}
 	}{
 		@@b4.form(routes.Application.mixed) {
-			@@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select a fruit" )
-			@@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-			@@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select a fruit" )
+			@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+			@@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
 		}
 	}
 
@@ -32,15 +32,15 @@
 	<h3 id="inline-form">The typical inline login form on top</h3>
 	@bsExampleWithCode {
 		@b4.inline.form(routes.Application.mixed) { implicit ifc =>
-			@b4.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@mail.com" )
-			@b4.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-			@b4.submit('class -> "btn btn-secondary"){ Sign in }
+			@b4.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@mail.com" )
+			@b4.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+			@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 		}
 	}{
 		@@b4.inline.form(routes.Application.mixed) { implicit ifc =>
-			@@b4.email( fooForm("foo"), '_hiddenLabel -> "Email", 'placeholder -> "example@@mail.com" )
-			@@b4.password( fooForm("foo"), '_hiddenLabel -> "Password", 'placeholder -> "Password" )
-			@@b4.submit('class -> "btn btn-secondary"){ Sign in }
+			@@b4.email( fooForm("foo"), Symbol("_hiddenLabel") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+			@@b4.password( fooForm("foo"), Symbol("_hiddenLabel") -> "Password", Symbol("placeholder") -> "Password" )
+			@@b4.submit(Symbol("class") -> "btn btn-secondary"){ Sign in }
 		}
 	}
 
@@ -50,21 +50,21 @@
 		<div class="row">
 		<div class="col-md-4">
 			@b4.vertical.form(routes.Application.mixed) { implicit vfc =>
-				@b4.text( fooForm("foo"), '_label -> "Your name", 'placeholder -> "Your contact name" )
-				@b4.email( fooForm("foo"), '_label -> "Your email", 'placeholder -> "example@mail.com" )
-				@b4.textarea( fooForm("foo"), '_label -> "What happened?", 'rows -> 3 )
-				@b4.checkbox( fooForm("foo"), '_text -> "Send me a copy to my email", 'checked -> true )
-				@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-envelope"></i> Send }
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Your name", Symbol("placeholder") -> "Your contact name" )
+				@b4.email( fooForm("foo"), Symbol("_label") -> "Your email", Symbol("placeholder") -> "example@mail.com" )
+				@b4.textarea( fooForm("foo"), Symbol("_label") -> "What happened?", Symbol("rows") -> 3 )
+				@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Send me a copy to my email", Symbol("checked") -> true )
+				@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-envelope"></i> Send }
 			}
 		</div>
 		</div>
 	}{
 		@@b4.vertical.form(routes.Application.mixed) { implicit vfc =>
-			@@b4.text( fooForm("foo"), '_label -> "Your name", 'placeholder -> "Your contact name" )
-			@@b4.email( fooForm("foo"), '_label -> "Your email", 'placeholder -> "example@@mail.com" )
-			@@b4.textarea( fooForm("foo"), '_label -> "What happened?", 'rows -> 3 )
-			@@b4.checkbox( fooForm("foo"), '_text -> "Send me a copy to my email", 'checked -> true )
-			@@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-envelope"></i> Send }
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Your name", Symbol("placeholder") -> "Your contact name" )
+			@@b4.email( fooForm("foo"), Symbol("_label") -> "Your email", Symbol("placeholder") -> "example@@mail.com" )
+			@@b4.textarea( fooForm("foo"), Symbol("_label") -> "What happened?", Symbol("rows") -> 3 )
+			@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Send me a copy to my email", Symbol("checked") -> true )
+			@@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-envelope"></i> Send }
 		}
 	}
 
@@ -72,17 +72,17 @@
 	<h3 id="horizontal-form">A different horizontal form</h3>
 	@bsExampleWithCode {
 		@b4.horizontal.form(routes.Application.mixed, "col-lg-4", "col-lg-8") { implicit hfc =>
-			@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@b4.file( fooForm("foo"), '_label -> "File" )
-			@b4.checkbox( fooForm("foo"), '_text -> "Checkbox" )
-			@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
+			@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@b4.file( fooForm("foo"), Symbol("_label") -> "File" )
+			@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox" )
+			@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
 		}
 	}{
 		@@b4.horizontal.form(routes.Application.mixed, "col-lg-4", "col-lg-8") { implicit hfc =>
-			@@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-			@@b4.file( fooForm("foo"), '_label -> "File" )
-			@@b4.checkbox( fooForm("foo"), '_text -> "Checkbox" )
-			@@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+			@@b4.file( fooForm("foo"), Symbol("_label") -> "File" )
+			@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox" )
+			@@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Save changes }
 		}
 	}
 
@@ -90,7 +90,7 @@
 	<h3 id="clear-form">A clear field constructor</h3>
 	@bsExampleWithCode {
 		@b4.clear.form(routes.Application.mixed) { implicit cfc =>
-			@b4.inputWrapped( "search", fooForm("foo"), 'placeholder -> "Text to search..." ) { input =>
+			@b4.inputWrapped( "search", fooForm("foo"), Symbol("placeholder") -> "Text to search..." ) { input =>
 				<div class="input-group">
 					<div class="input-group-prepend">
 						<span class="input-group-text"><i class="fa fa-search"></i></span>
@@ -104,7 +104,7 @@
 		}
 	}{
 		@@b4.clear.form(routes.Application.mixed) { implicit cfc =>
-			@@b4.inputWrapped( "search", fooForm("foo"), 'placeholder -> "Text to search..." ) { input =>
+			@@b4.inputWrapped( "search", fooForm("foo"), Symbol("placeholder") -> "Text to search..." ) { input =>
 				<div class="input-group">
 					<div class="input-group-prepend">
 						<span class="input-group-text"><i class="fa fa-search"></i></span>

--- a/play27-bootstrap4/sample/app/views/multifield.scala.html
+++ b/play27-bootstrap4/sample/app/views/multifield.scala.html
@@ -19,64 +19,64 @@
 
 		<h3 id="daterange">A date range</h3>
 		@bsExampleWithCode {
-			@b4.datepicker( fooForm("dateStart"), 'value -> "15-11-2014" )(
-				fooForm("dateEnd"), 'value -> "31-12-2014" )(
-				'_label -> "Date range", "data-date-start-date" -> "10-11-2014", '_help -> "Select a date range from 10-11-2014" )
+			@b4.datepicker( fooForm("dateStart"), Symbol("value") -> "15-11-2014" )(
+				fooForm("dateEnd"), Symbol("value") -> "31-12-2014" )(
+				Symbol("_label") -> "Date range", "data-date-start-date" -> "10-11-2014", Symbol("_help") -> "Select a date range from 10-11-2014" )
 		}{
-			@@b4.datepicker( fooForm("dateStart"), 'value -> "31-10-2014" )(
-				fooForm("dateEnd"), 'value -> "31-12-2014" )(
-				'_label -> "Date range", "data-date-start-date" -> "01-01-2014", '_help -> "Select a date range from 10-11-2014" )
+			@@b4.datepicker( fooForm("dateStart"), Symbol("value") -> "31-10-2014" )(
+				fooForm("dateEnd"), Symbol("value") -> "31-12-2014" )(
+				Symbol("_label") -> "Date range", "data-date-start-date" -> "01-01-2014", Symbol("_help") -> "Select a date range from 10-11-2014" )
 		}
 
 		<h3 id="set-checkboxes">A set of checkboxes</h3>
 		@bsExampleWithCode {
 			@b4.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)( '_label -> "Checkboxes", 'class -> "multi-checkbox-list", '_help -> "Mark what you want" )
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)( Symbol("_label") -> "Checkboxes", Symbol("class") -> "multi-checkbox-list", Symbol("_help") -> "Mark what you want" )
 			@b4.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)('_label -> "Inline", 'class -> "multi-checkbox-list inline", '_help -> "Mark what you want")
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)(Symbol("_label") -> "Inline", Symbol("class") -> "multi-checkbox-list inline", Symbol("_help") -> "Mark what you want")
 		}{
 			@@b4.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)('_label -> "Checkboxes", 'class -> "multi-checkbox-list", '_help -> "Mark what you want")
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)(Symbol("_label") -> "Checkboxes", Symbol("class") -> "multi-checkbox-list", Symbol("_help") -> "Mark what you want")
 			@@b4.multiCheckbox(
-				(fooForm("foo"), Seq('_text -> "Foo")),
-				(fooForm("bar"), Seq('_text -> "Bar")),
-				(fooForm("beer"), Seq('_text -> "Beer"))
-				)('_label -> "Inline", 'class -> "multi-checkbox-list inline", '_help -> "Mark what you want")
+				(fooForm("foo"), Seq(Symbol("_text") -> "Foo")),
+				(fooForm("bar"), Seq(Symbol("_text") -> "Bar")),
+				(fooForm("beer"), Seq(Symbol("_text") -> "Beer"))
+				)(Symbol("_label") -> "Inline", Symbol("class") -> "multi-checkbox-list inline", Symbol("_help") -> "Mark what you want")
 		}
 
 		<h3 id="text-with-checkbox">A textfield with a checkbox addon</h3>
 		@bsExampleWithCode {
-			@b4.textWithCheckbox( fooForm("foo"), 'placeholder -> "a foo value" )( fooForm("fooSelected") )('_label -> "New task" )
+			@b4.textWithCheckbox( fooForm("foo"), Symbol("placeholder") -> "a foo value" )( fooForm("fooSelected") )(Symbol("_label") -> "New task" )
 		}{
-			@@b4.textWithCheckbox( fooForm("foo"), 'placeholder -> "a foo value" )( fooForm("fooSelected") )('_label -> "New task" )
+			@@b4.textWithCheckbox( fooForm("foo"), Symbol("placeholder") -> "a foo value" )( fooForm("fooSelected") )(Symbol("_label") -> "New task" )
 		}
 
 		<h3 id="validation-states">Validation states and feedback icons</h3>
 		@bsExampleWithCode {
-			@b4.datepicker( fooForm("dateStart"), 'value -> "15-11-2014" )(
-				fooForm("dateEnd"), 'value -> "31-10-2014", '_error -> "error!" )(
-				'_label -> "Date range" )
+			@b4.datepicker( fooForm("dateStart"), Symbol("value") -> "15-11-2014" )(
+				fooForm("dateEnd"), Symbol("value") -> "31-10-2014", Symbol("_error") -> "error!" )(
+				Symbol("_label") -> "Date range" )
 
-			@b4.textWithCheckbox( fooForm("foo"), 'value -> "an incorrect value", '_error -> "The value is incorrect" )(
+			@b4.textWithCheckbox( fooForm("foo"), Symbol("value") -> "an incorrect value", Symbol("_error") -> "The value is incorrect" )(
 				fooForm("fooSelected") )(
-				'_label -> "New task" )
+				Symbol("_label") -> "New task" )
 		}{
-			@@b4.datepicker( fooForm("dateStart"), 'value -> "15-11-2014" )(
-				fooForm("dateEnd"), 'value -> "31-10-2014", '_error -> "error!" )(
-				'_label -> "Date range" )
+			@@b4.datepicker( fooForm("dateStart"), Symbol("value") -> "15-11-2014" )(
+				fooForm("dateEnd"), Symbol("value") -> "31-10-2014", Symbol("_error") -> "error!" )(
+				Symbol("_label") -> "Date range" )
 
-			@@b4.textWithCheckbox( fooForm("foo"), 'value -> "an incorrect value", '_error -> "The value is incorrect" )(
+			@@b4.textWithCheckbox( fooForm("foo"), Symbol("value") -> "an incorrect value", Symbol("_error") -> "The value is incorrect" )(
 				fooForm("fooSelected") )(
-				'_label -> "New task" )
+				Symbol("_label") -> "New task" )
 		}
 
 	}

--- a/play27-bootstrap4/sample/app/views/readonly.scala.html
+++ b/play27-bootstrap4/sample/app/views/readonly.scala.html
@@ -14,21 +14,21 @@
 		<code>checkbox</code>, <code>radio</code> and <code>select</code> helpers.
 	</p>
 
-  @b4.formCSRF(Call("GET", ""), 'id -> "form-readonly") {
+  @b4.formCSRF(Call("GET", ""), Symbol("id") -> "form-readonly") {
 		@bsExampleWithCode {
-			@b4.text( fooForm("text"), '_label -> "Always editable", '_class -> "always-editable", 'value -> "demo text", 'placeholder -> "A simple text..." )
-			@b4.checkbox( fooForm("checkbox"), '_text -> "Checkbox", 'value -> true, 'readonly -> true )
-			@b4.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), 'value -> "M", '_label -> "Radio Group", 'readonly -> true )
-			@b4.select( fooForm("select"), options = fruits, '_label -> "Select", 'value -> "A", 'readonly -> true )
+			@b4.text( fooForm("text"), Symbol("_label") -> "Always editable", Symbol("_class") -> "always-editable", Symbol("value") -> "demo text", Symbol("placeholder") -> "A simple text..." )
+			@b4.checkbox( fooForm("checkbox"), Symbol("_text") -> "Checkbox", Symbol("value") -> true, Symbol("readonly") -> true )
+			@b4.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), Symbol("value") -> "M", Symbol("_label") -> "Radio Group", Symbol("readonly") -> true )
+			@b4.select( fooForm("select"), options = fruits, Symbol("_label") -> "Select", Symbol("value") -> "A", Symbol("readonly") -> true )
 			@b4.free() {
 				<button type="submit" class="btn btn-secondary"><i class="fa fa-ok"></i> Submit me!</button>
 				<a class="btn btn-primary btn-readonly-unlock locked" href>Unlock readonly fields</a>
 			}
 		}{
-			@@b4.text( fooForm("text"), '_label -> "Always editable", '_class -> "always-editable", 'value -> "demo text", 'placeholder -> "A simple text..." )
-			@@b4.checkbox( fooForm("checkbox"), '_text -> "Checkbox", 'value -> true, 'readonly -> true )
-			@@b4.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), 'value -> "M", '_label -> "Radio Group", 'readonly -> true )
-			@@b4.select( fooForm("select"), options = fruits, '_label -> "Select", 'value -> "A", 'readonly -> true )
+			@@b4.text( fooForm("text"), Symbol("_label") -> "Always editable", Symbol("_class") -> "always-editable", Symbol("value") -> "demo text", Symbol("placeholder") -> "A simple text..." )
+			@@b4.checkbox( fooForm("checkbox"), Symbol("_text") -> "Checkbox", Symbol("value") -> true, Symbol("readonly") -> true )
+			@@b4.radio( fooForm("radio"), options = Seq("M"->"Male","F"->"Female"), Symbol("value") -> "M", Symbol("_label") -> "Radio Group", Symbol("readonly") -> true )
+			@@b4.select( fooForm("select"), options = fruits, Symbol("_label") -> "Select", Symbol("value") -> "A", Symbol("readonly") -> true )
 			@@b4.free() {
 				<button type="submit" class="btn btn-secondary"><i class="fa fa-ok"></i> Submit me!</button>
 				<a class="btn btn-primary btn-readonly-unlock locked" href>Unlock readonly fields</a>

--- a/play27-bootstrap4/sample/app/views/vertical.scala.html
+++ b/play27-bootstrap4/sample/app/views/vertical.scala.html
@@ -14,40 +14,40 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b4.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b4.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@mail.com" )
 			</div>
 			<div class="col-md-6">
-				@b4.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-				@b4.file( fooForm("foo"), '_label -> "File" )
+				@b4.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+				@b4.file( fooForm("foo"), Symbol("_label") -> "File" )
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b4.email( fooForm("foo"), '_label -> "Email", 'placeholder -> "example@@mail.com" )
-		@@b4.password( fooForm("foo"), '_label -> "Password", 'placeholder -> "Password" )
-		@@b4.file( fooForm("foo"), '_label -> "File" )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b4.email( fooForm("foo"), Symbol("_label") -> "Email", Symbol("placeholder") -> "example@@mail.com" )
+		@@b4.password( fooForm("foo"), Symbol("_label") -> "Password", Symbol("placeholder") -> "Password" )
+		@@b4.file( fooForm("foo"), Symbol("_label") -> "File" )
 	}
 
 	<h3 id="more-options">More options</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-				@b4.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-				@b4.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
 			</div>
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), 'placeholder -> "Without label" )
-				@b4.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control form-control-lg", 'placeholder -> "An awesome field..." )
+				@b4.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control form-control-lg", Symbol("placeholder") -> "An awesome field..." )
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Input Text", 'placeholder -> "A simple text..." )
-		@@b4.text( fooForm("foo"), '_label -> "Help", '_help -> "This is a help text", 'placeholder -> "A simple text showing a help..." )
-		@@b4.text( fooForm("foo"), '_label -> "Constraints", '_showConstraints -> true, 'placeholder -> "A simple text showing its constraints..." )
-		@@b4.text( fooForm("foo"), 'placeholder -> "Without label" )
-		@@b4.text( fooForm("foo"), '_label -> "A big text", 'class -> "form-control form-control-lg", 'placeholder -> "An awesome field..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Input Text", Symbol("placeholder") -> "A simple text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Help", Symbol("_help") -> "This is a help text", Symbol("placeholder") -> "A simple text showing a help..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Constraints", Symbol("_showConstraints") -> true, Symbol("placeholder") -> "A simple text showing its constraints..." )
+		@@b4.text( fooForm("foo"), Symbol("placeholder") -> "Without label" )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "A big text", Symbol("class") -> "form-control form-control-lg", Symbol("placeholder") -> "An awesome field..." )
 	}
 
 
@@ -55,69 +55,69 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-				@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-				@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+				@b4.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+				@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+				@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 			</div>
 			<div class="col-md-6">
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 			</div>
 		</div>
 	}{
-		@@b4.textarea( fooForm("foo"), '_label -> "Textarea", 'rows -> 3 )
-		@@b4.checkbox( fooForm("foo"), '_text -> "Checkbox", 'checked -> true )
-		@@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
+		@@b4.textarea( fooForm("foo"), Symbol("_label") -> "Textarea", Symbol("rows") -> 3 )
+		@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+		@@b4.radio( fooForm("foo"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
 
 		@@fruits = @@{ Seq("A"->"Apples","P"->"Pears","B"->"Bananas") }
 		...
-		@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select" )
-		@@b4.select( fooForm("foo"), options = fruits, '_label -> "Multiple Select", 'multiple -> true )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select" )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Multiple Select", Symbol("multiple") -> true )
 	}
 
 	<h3 id="disabled-readonly-attributes">Disabled and readonly attributes</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-				@b4.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+				@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
 			</div>
 			<div class="col-md-6">
-				@b4.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+				@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Disabled", 'disabled -> true, 'placeholder -> "Disabled text..." )
-		@@b4.checkbox( fooForm("foo"), '_text -> "Readonly checkbox", 'readonly -> true, 'value -> true )
-		@@b4.select( fooForm("foo"), options = fruits, '_label -> "Select", 'multiple -> true, 'readonly -> true, 'value -> "B,P" )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Disabled", Symbol("disabled") -> true, Symbol("placeholder") -> "Disabled text..." )
+		@@b4.checkbox( fooForm("foo"), Symbol("_text") -> "Readonly checkbox", Symbol("readonly") -> true, Symbol("value") -> true )
+		@@b4.select( fooForm("foo"), options = fruits, Symbol("_label") -> "Select", Symbol("multiple") -> true, Symbol("readonly") -> true, Symbol("value") -> "B,P" )
 	}
 
 	<h3 id="validation-states">Validation states</h3>
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-				@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-				@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+				@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text..." )
 			</div>
 			<div class="col-md-6">
-				@b4.vertical.form(routes.Application.vertical, '_feedbackTooltip -> true) { implicit fc =>
-					@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text...", '_class -> "position-relative" )
-					@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text...", '_class -> "position-relative" )
-					@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text...", '_class -> "position-relative" )
+				@b4.vertical.form(routes.Application.vertical, Symbol("_feedbackTooltip") -> true) { implicit fc =>
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text...", Symbol("_class") -> "position-relative" )
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text...", Symbol("_class") -> "position-relative" )
+					@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text...", Symbol("_class") -> "position-relative" )
 				}
 			</div>
 		</div>
 	}{
-		@@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text..." )
-		@@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text..." )
-		@@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text..." )
+		@@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text..." )
 
 		// With feedback tooltips
-		@@b4.vertical.form(routes.Application.vertical, '_feedbackTooltip -> true) { implicit fc =>
-			@@b4.text( fooForm("foo"), '_label -> "Success", '_success -> "Great!", 'placeholder -> "Success text...", '_class -> "position-relative" )
-			@@b4.text( fooForm("foo"), '_label -> "Warning", '_warning -> "Be carefull with this...", 'placeholder -> "Warning text...", '_class -> "position-relative" )
-			@@b4.text( fooForm("foo"), '_label -> "Error", '_error -> "An error occurred!", '_help -> "Another help text", 'placeholder -> "Error text...", '_class -> "position-relative" )
+		@@b4.vertical.form(routes.Application.vertical, Symbol("_feedbackTooltip") -> true) { implicit fc =>
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Success", Symbol("_success") -> "Great!", Symbol("placeholder") -> "Success text...", Symbol("_class") -> "position-relative" )
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Warning", Symbol("_warning") -> "Be carefull with this...", Symbol("placeholder") -> "Warning text...", Symbol("_class") -> "position-relative" )
+			@@b4.text( fooForm("foo"), Symbol("_label") -> "Error", Symbol("_error") -> "An error occurred!", Symbol("_help") -> "Another help text", Symbol("placeholder") -> "Error text...", Symbol("_class") -> "position-relative" )
 		}
 	}
 
@@ -125,29 +125,29 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true, '_custom -> true )
-				@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group", '_custom -> true )
+				@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true, Symbol("_custom") -> true )
+				@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group", Symbol("_custom") -> true )
 			</div>
 			<div class="col-md-6">
-				@b4.vertical.form(routes.Application.vertical, '_custom -> true) { implicit fc =>
-					@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select" )
-					@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file..." )
+				@b4.vertical.form(routes.Application.vertical, Symbol("_custom") -> true) { implicit fc =>
+					@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select" )
+					@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file..." )
 				}
 			</div>
 		</div>
 }{
-		@@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true, '_custom -> true )
-		@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group", '_custom -> true )
-		@@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select", '_custom -> true )
-		@@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file...", '_custom -> true )
+		@@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true, Symbol("_custom") -> true )
+		@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group", Symbol("_custom") -> true )
+		@@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select", Symbol("_custom") -> true )
+		@@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file...", Symbol("_custom") -> true )
 
 		Or
 
-		@@b4.vertical.form(routes.Application.vertical, '_custom -> true) { implicit fc =>
-			@@b4.checkbox( fooForm("foo_check_custom_1"), '_text -> "Checkbox", 'checked -> true )
-			@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), '_label -> "Radio Group" )
-			@@b4.select( fooForm("foo_select_custom_1"), options = fruits, '_label -> "Select" )
-			@@b4.file( fooForm("foo_file_custom_1"), '_label -> "File", 'placeholder -> "Select a file..." )
+		@@b4.vertical.form(routes.Application.vertical, Symbol("_custom") -> true) { implicit fc =>
+			@@b4.checkbox( fooForm("foo_check_custom_1"), Symbol("_text") -> "Checkbox", Symbol("checked") -> true )
+			@@b4.radio( fooForm("foo_radio_custom_1"), options = Seq("M"->"Male","F"->"Female"), Symbol("_label") -> "Radio Group" )
+			@@b4.select( fooForm("foo_select_custom_1"), options = fruits, Symbol("_label") -> "Select" )
+			@@b4.file( fooForm("foo_file_custom_1"), Symbol("_label") -> "File", Symbol("placeholder") -> "Select a file..." )
 		}
 }
 
@@ -155,7 +155,7 @@
 	@bsExampleWithCode {
 		<div class="row">
 			<div class="col-md-6">
-				@b4.inputWrapped( "email", fooForm("foo"), '_label -> "Input group", 'placeholder -> "Custom input group for email..." ) { input =>
+				@b4.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 					<div class="input-group">
 						<div class="input-group-prepend">
 							<span class="input-group-text">@@</span>
@@ -163,7 +163,7 @@
 						@input
 					</div>
 				}
-				@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+				@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 					<div class="input-number input-group">
 						<div class="input-group-prepend">
 							<span class="input-group-text input-number-minus"><i class="fa fa-minus"></i></span>
@@ -176,7 +176,7 @@
 				}
 			</div>
 			<div class="col-md-6">
-				@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+				@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 					<div class="input-group">
 						<div class="input-group-prepend">
 							<span class="input-group-text"><i class="fa fa-star"></i></span>
@@ -200,7 +200,7 @@
 			</div>
 		</div>
 	}{
-		@@b4.inputWrapped( "email", fooForm("foo"), '_label -> "Simple input group", 'placeholder -> "Custom input group for email..." ) { input =>
+		@@b4.inputWrapped( "email", fooForm("foo"), Symbol("_label") -> "Simple input group", Symbol("placeholder") -> "Custom input group for email..." ) { input =>
 			<div class="input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text">@@@@</span>
@@ -208,7 +208,7 @@
 				@@input
 			</div>
 		}
-		@@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Fully customized", 'placeholder -> "A complicated one..." ) { input =>
+		@@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Fully customized", Symbol("placeholder") -> "A complicated one..." ) { input =>
 			<div class="input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text"><i class="fa fa-star"></i></span>
@@ -219,7 +219,7 @@
 				</div>
 			</div>
 		}
-		@@b4.inputWrapped( "text", fooForm("foo"), '_label -> "Number", 'value -> 0, '_help -> "This needs some JavaScript and CSS" ) { input =>
+		@@b4.inputWrapped( "text", fooForm("foo"), Symbol("_label") -> "Number", Symbol("value") -> 0, Symbol("_help") -> "This needs some JavaScript and CSS" ) { input =>
 			<div class="input-number input-group">
 				<div class="input-group-prepend">
 					<span class="input-group-text input-number-minus"><i class="fa fa-minus"></i></span>
@@ -235,14 +235,14 @@
 	<h3 id="more-helpers">More helpers</h3>
 	@bsExampleWithCode {
 		@b4.static("Static HTML"){ <a href="#"><i class="fa fa-star"></i> This is a link</a> }
-		@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
+		@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
 		@b4.free() {
 			<button type="submit" class="btn btn-primary"> <i class="fa fa-ok"></i> Save changes</button>
 			<a class="btn btn-secondary"> <i class="fa fa-remove"></i> Cancel</a>
 		}
 	}{
 		@@b4.static("Static HTML"){ <a href="#"><i class="fa fa-star"></i> This is a link</a> }
-		@@b4.submit('class -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
+		@@b4.submit(Symbol("class") -> "btn btn-secondary"){ <i class="fa fa-ok"></i> Submit me! }
 		@@b4.free() {
 			<button type="submit" class="btn btn-primary"> <i class="fa fa-ok"></i> Save changes</button>
 			<a class="btn btn-secondary"> <i class="fa fa-remove"></i> Cancel</a>


### PR DESCRIPTION
Only effects the Play 2.7 folders: `core-play27`, `play27-bootstrap3`, `play27-bootstrap4` (because of Scala 2.13 support)

I did not do this manually. The first four commits were done via regex, effecting the `*.scala.html` files only:
```    
find core-play27/ play27-bootstrap3/ play27-bootstrap4/ -name *.scala.html | xargs sed -i "s/'\([^> ]\+\) ->/Symbol(\"\1\") ->/g"
find core-play27/ play27-bootstrap3/ play27-bootstrap4/ -name *.scala.html | xargs sed -i "s/get('\([^) ]\+\))/get(Symbol(\"\1\"))/g"
find core-play27/ play27-bootstrap3/ play27-bootstrap4/ -name *.scala.html | xargs sed -i "s/'\([^) ]\+\))/Symbol(\"\1\"))/g"
find core-play27/ play27-bootstrap3/ play27-bootstrap4/ -name *.scala.html | xargs sed -i "s/'\([^, ]\+\),/Symbol(\"\1\"),/g"
```
The fifth commit was done via [`sbt-scalafix`](https://github.com/scalacenter/sbt-scalafix) and [`Scalafix Rewrites`](https://github.com/scala/scala-rewrites) - to fix all the `*.scala` files. I temporarly added it to `project/plugins.sbt` / `build.sbt`, see [this commit](https://github.com/mkurz/play-bootstrap/commit/be61cb84738e90fbfda3148fd9ae3b8c0f37b75a) (in my own branch). I had to clone https://github.com/scala/scala-rewrites before and [`publishLocal` it](https://github.com/scala/scala-rewrites#scalafix-rewrites-for-scala). Then I could run it via:
```scala
cd core-play27/
sbt clean "scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
sbt clean "test:scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
cd ../play27-bootstrap3/module/
sbt clean "scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
sbt clean "test:scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
cd ../sample/
sbt clean "scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
sbt clean "test:scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
cd ../../play27-bootstrap4/module/
sbt clean "scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
sbt clean "test:scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
cd ../sample/
sbt clean "scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
sbt clean "test:scalafix dependency:fix.scala213.Core@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT"
cd ../../
```
See
* https://github.com/scalacenter/scalafix/issues/977
* https://github.com/scala/scala-rewrites/blob/2e40d60acdd5ef37e6368ff1830d4df1bd1d948d/rewrites/src/main/scala/impl/Substitutions.scala#L125-L127