### PR TITLE
Reduce dependencies

### DIFF
--- a/core-play26/build.sbt
+++ b/core-play26/build.sbt
@@ -9,9 +9,11 @@ crossScalaVersions := Seq("2.12.8", "2.11.12")
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters, PlayLogback, PlayAkkaHttpServer)
 
-
+libraryDependencies := libraryDependencies.value.filterNot(m => m.name == "twirl-api" || m.name == "play-server") ++ Seq(
+  playCore % "provided"
+)
 
 scalariformSettings
 

--- a/core-play27/build.sbt
+++ b/core-play27/build.sbt
@@ -11,8 +11,11 @@ crossScalaVersions := Seq("2.13.0", "2.12.8")
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters, PlayLogback, PlayAkkaHttpServer)
 
+libraryDependencies := libraryDependencies.value.filterNot(m => m.name == "twirl-api" || m.name == "play-server") ++ Seq(
+  playCore % "provided"
+)
 
 scalariformPreferences := scalariformPreferences.value
   .setPreference(AlignSingleLineCaseStatements, true)

--- a/play26-bootstrap3/module/build.sbt
+++ b/play26-bootstrap3/module/build.sbt
@@ -11,13 +11,14 @@ resolvers ++= Seq(
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 )
 
-libraryDependencies ++= Seq(
+libraryDependencies := libraryDependencies.value.filterNot(m => m.name == "twirl-api" || m.name == "play-server") ++ Seq(
+  playCore % "provided",
   filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.5.1-P26",
   specs2 % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters, PlayLogback, PlayAkkaHttpServer)
 
 
 

--- a/play26-bootstrap4/module/build.sbt
+++ b/play26-bootstrap4/module/build.sbt
@@ -11,13 +11,14 @@ resolvers ++= Seq(
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 )
 
-libraryDependencies ++= Seq(
+libraryDependencies := libraryDependencies.value.filterNot(m => m.name == "twirl-api" || m.name == "play-server") ++ Seq(
+  playCore % "provided",
   filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.5.1-P26",
   specs2 % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters, PlayLogback, PlayAkkaHttpServer)
 
 
 

--- a/play27-bootstrap3/module/build.sbt
+++ b/play27-bootstrap3/module/build.sbt
@@ -13,13 +13,14 @@ resolvers ++= Seq(
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 )
 
-libraryDependencies ++= Seq(
+libraryDependencies := libraryDependencies.value.filterNot(m => m.name == "twirl-api" || m.name == "play-server") ++ Seq(
+  playCore % "provided",
   filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.5.1-P27",
   specs2 % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters, PlayLogback, PlayAkkaHttpServer)
 
 scalariformPreferences := scalariformPreferences.value
   .setPreference(AlignSingleLineCaseStatements, true)

--- a/play27-bootstrap4/module/build.sbt
+++ b/play27-bootstrap4/module/build.sbt
@@ -13,13 +13,14 @@ resolvers ++= Seq(
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 )
 
-libraryDependencies ++= Seq(
+libraryDependencies := libraryDependencies.value.filterNot(m => m.name == "twirl-api" || m.name == "play-server") ++ Seq(
+  playCore % "provided",
   filters % "provided",
   "com.adrianhurt" %% "play-bootstrap-core" % "1.5.1-P27",
   specs2 % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)
+lazy val root = (project in file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters, PlayLogback, PlayAkkaHttpServer)
 
 scalariformPreferences := scalariformPreferences.value
   .setPreference(AlignSingleLineCaseStatements, true)


### PR DESCRIPTION
Looking at
https://repo1.maven.org/maven2/com/adrianhurt/play-bootstrap-core_2.13/1.5.1-P27/play-bootstrap-core_2.13-1.5.1-P27.pom
and
https://repo1.maven.org/maven2/com/adrianhurt/play-bootstrap_2.13/1.5.1-P27-B4/play-bootstrap_2.13-1.5.1-P27-B4.pom

there are dependencies which are not needed for play-bootstrap.
First we can disable filters we don't need. Plus we can remove `play-server` which is definitely not needed, and also remove `twirl-api` and instead add `playCore` as `provided` (which itself depends on `twirl-api`, so it's transitively added anyway).